### PR TITLE
fix: qr-code icon misalign

### DIFF
--- a/entry/src/main/ets/pages/Index.ets
+++ b/entry/src/main/ets/pages/Index.ets
@@ -404,8 +404,9 @@ struct Index {
         });
         this.dialog_qrcode.open();
       })
-      .margin({ right: 10 })
     }
+    .margin({ right: 10 })
+    .width(50)
   }
 
   @Builder


### PR DESCRIPTION
#36 相关

给`TokenItemStart`中Row添加了宽度，去除`Button`组件的`.margin({ right: 10 })`，移给`Row`组件

虚拟机（手机和平板）测试问题解决，且二维码图标会跟随令牌`ListItem`组件移动。