### PR TITLE
fix: 导入otp文本链接时，若issuer为steam，则设定TokenType为steam

### DIFF
--- a/entry/src/main/ets/dialogs/FortiConfigDialog.ets
+++ b/entry/src/main/ets/dialogs/FortiConfigDialog.ets
@@ -1,4 +1,4 @@
-import { TokenConfig } from '../utils/TokenConfig';
+import { otpType, TokenConfig } from '../utils/TokenConfig';
 import { base32Decode, base32Encode, stringToIntArray, ScanBarCode } from '../utils/TokenUtils'
 import { http } from '@kit.NetworkKit';
 import { BusinessError } from '@kit.BasicServicesKit';
@@ -28,7 +28,7 @@ class  forti_server_resp {
 export struct FortiConfigDialog {
   controller?: CustomDialogController;
   @Prop conf_json?: string = '';
-  @State conf: TokenConfig = new TokenConfig('', 1, 'Forti', 'User', 'SHA1', 60, 6);
+  @State conf: TokenConfig = new TokenConfig('', otpType.Forti, 'Forti', 'User', 'SHA1', 60, 6);
   @State btn_camera_clicked: number = 0;
   @State btn_dev_id_clicked: number = 0;
   @State warn_dev_id_popup: boolean = false;

--- a/entry/src/main/ets/dialogs/SteamConfigDialog.ets
+++ b/entry/src/main/ets/dialogs/SteamConfigDialog.ets
@@ -1,4 +1,4 @@
-import { TokenConfig } from '../utils/TokenConfig';
+import { otpType, TokenConfig } from '../utils/TokenConfig';
 import { JSON, url } from '@kit.ArkTS';
 import { ScanBarCode } from '../utils/TokenUtils';
 import { TokenIcon } from '../components/TokenIcon';
@@ -11,7 +11,7 @@ import { SelectIconDialog } from './SelectIconDialog';
 export struct SteamConfigDialog {
   controller?: CustomDialogController;
   @Prop conf_json?: string = '';
-  @State conf: TokenConfig = new TokenConfig('', 3, 'Steam', 'User', 'SHA1', 30, 10);
+  @State conf: TokenConfig = new TokenConfig('', otpType.Steam, 'Steam', 'User', 'SHA1', 30, 10);
   @State btn_camera_clicked: number = 0;
 
   cancel?: () => void;

--- a/entry/src/main/ets/dialogs/URIConfigDialog.ets
+++ b/entry/src/main/ets/dialogs/URIConfigDialog.ets
@@ -62,6 +62,14 @@ export struct URIConfigDialog {
       token.TokenCounter = parseInt(parameters['counter'] ?? '0');
       token.TokenDigits = parseInt(parameters['digits'] ?? '6');
 
+      // otpauth://totp/Steam:xxx?secret=XXXXXXXXXXXXXXXXXXXXXXX&issuer=Steam
+      if(token.TokenIssuer.toLowerCase()=='steam'){
+        token.TokenType = otpType.Steam;
+        token.TokenAlgorithm = 'SHA1'
+        token.TokenPeriod = 30
+        token.TokenDigits = 10
+      }
+
       tokens.push(token);
     });
 


### PR DESCRIPTION
如题