### PR TITLE
feat: Token and progress color change when less than 5 seconds

### DIFF
--- a/entry/src/main/ets/components/TokenItem.ets
+++ b/entry/src/main/ets/components/TokenItem.ets
@@ -31,8 +31,8 @@ export struct TokenItem {
     ])
   private token_progress_color_near_next: LinearGradient = new LinearGradient(
     [
-      {color: $r('app.color.token_progress_next_color_start'), offset: 1},
-      {color: $r('app.color.token_progress_next_color_end'), offset: 0},
+      {color: $r('app.color.token_progress_next_color_start'), offset: 0},
+      {color: $r('app.color.token_progress_next_color_end'), offset: 1},
     ])
 
   aboutToAppear(): void {

--- a/entry/src/main/ets/components/TokenItem.ets
+++ b/entry/src/main/ets/components/TokenItem.ets
@@ -23,6 +23,17 @@ export struct TokenItem {
   @Local TokenHide: boolean = current_token_hide_map[this.Config.TokenUUID] ?? true;
 
   private token_steps: number = 0;
+  private token_color_change_threshold = 5;
+  private token_progress_color_normal: LinearGradient = new LinearGradient(
+    [
+      {color: $r('app.color.token_progress_normal_color_start'), offset: 0},
+      {color: $r('app.color.token_progress_normal_color_end'), offset: 1},
+    ])
+  private token_progress_color_near_next: LinearGradient = new LinearGradient(
+    [
+      {color: $r('app.color.token_progress_next_color_start'), offset: 1},
+      {color: $r('app.color.token_progress_next_color_end'), offset: 0},
+    ])
 
   aboutToAppear(): void {
     getContext(this).eventHub.on('onTimestampChanged', (timestamp: number, force: boolean) => this.onTimestampChanged(timestamp, force));
@@ -107,7 +118,7 @@ export struct TokenItem {
             .textAlign(TextAlign.End)
             .textOverflow({ overflow: TextOverflow.MARQUEE })
             .maxLines(1)
-            .fontColor($r('app.color.token_number'))
+            .fontColor(this.TokenLeftPeriod <= this.token_color_change_threshold ? Color.Red : $r('app.color.token_number'))
             .fontSize(30)
             .gesture(
               LongPressGesture()
@@ -158,6 +169,9 @@ export struct TokenItem {
               .style({ strokeWidth: 8 })
               .width(40)
               .height(40)
+              .color(this.TokenLeftPeriod <= this.token_color_change_threshold ?
+                this.token_progress_color_near_next :
+                this.token_progress_color_normal)
           }
         }
       }

--- a/entry/src/main/ets/components/TokenItem.ets
+++ b/entry/src/main/ets/components/TokenItem.ets
@@ -118,7 +118,9 @@ export struct TokenItem {
             .textAlign(TextAlign.End)
             .textOverflow({ overflow: TextOverflow.MARQUEE })
             .maxLines(1)
-            .fontColor(this.TokenLeftPeriod <= this.token_color_change_threshold ? Color.Red : $r('app.color.token_number'))
+            .fontColor(this.TokenLeftPeriod <= this.token_color_change_threshold ?
+              $r('app.color.token_progress_next_color_end') :
+              $r('app.color.token_number'))
             .fontSize(30)
             .gesture(
               LongPressGesture()

--- a/entry/src/main/resources/base/element/color.json
+++ b/entry/src/main/resources/base/element/color.json
@@ -47,6 +47,22 @@
     {
       "name": "icon_pack_bg",
       "value": "#FFECEBEB"
+    },
+    {
+      "name": "token_progress_normal_color_start",
+      "value": "#FF86c1ff"
+    },
+    {
+      "name": "token_progress_normal_color_end",
+      "value": "#FF254ff7"
+    },
+    {
+      "name": "token_progress_next_color_start",
+      "value": "#FFD71616"
+    },
+    {
+      "name": "token_progress_next_color_end",
+      "value": "#FFF18585"
     }
   ]
 }

--- a/entry/src/main/resources/base/element/color.json
+++ b/entry/src/main/resources/base/element/color.json
@@ -58,11 +58,11 @@
     },
     {
       "name": "token_progress_next_color_start",
-      "value": "#FFD71616"
+      "value": "#FFF18585"
     },
     {
       "name": "token_progress_next_color_end",
-      "value": "#FFF18585"
+      "value": "#FFD71616"
     }
   ]
 }


### PR DESCRIPTION
#50 相关

令牌倒计时5秒内，令牌和进度圈变为红色。

效果图：
![图片](https://github.com/user-attachments/assets/df5f0c36-e61d-428f-867f-9984f0989576)
