### PR TITLE
修复: 文本链接或扫码导入时，密钥会统一改变为小写（虽然实际上不影响计算结果）

### DIFF
--- a/entry/src/main/ets/dialogs/OTPConfigDialog.ets
+++ b/entry/src/main/ets/dialogs/OTPConfigDialog.ets
@@ -71,11 +71,13 @@ export struct TOTPConfigDialog {
     const parameters: Record<string, string> = {};
     const tail_part = otp_url.href.split('?');
     if (tail_part.length > 1) {
-      const query = tail_part[1].toLowerCase();
+      const query = tail_part[1];
       if (query) {
         query.split('&').forEach(part => {
           const kv: string[] = part.split('=');
-          parameters[kv[0]] = kv[1];
+          //保留secret的大小写
+          if(kv[0].toLowerCase()=='secret')parameters[kv[0].toLowerCase()] = kv[1];
+          else parameters[kv[0].toLowerCase()] = kv[1].toLowerCase();
         });
       }
       this.conf.TokenSecret = parameters['secret'];

--- a/entry/src/main/ets/dialogs/SteamConfigDialog.ets
+++ b/entry/src/main/ets/dialogs/SteamConfigDialog.ets
@@ -62,11 +62,13 @@ export struct SteamConfigDialog {
     const parameters: Record<string, string> = {};
     const tail_part = otp_url.href.split('?');
     if (tail_part.length > 1) {
-      const query = tail_part[1].toLowerCase();
+      const query = tail_part[1];
       if (query) {
         query.split('&').forEach(part => {
           const kv: string[] = part.split('=');
-          parameters[kv[0]] = kv[1];
+          //保留secret的大小写
+          if(kv[0].toLowerCase()=='secret')parameters[kv[0].toLowerCase()] = kv[1];
+          else parameters[kv[0].toLowerCase()] = kv[1].toLowerCase();
         });
       }
       this.conf.TokenSecret = parameters['secret'];

--- a/entry/src/main/ets/dialogs/URIConfigDialog.ets
+++ b/entry/src/main/ets/dialogs/URIConfigDialog.ets
@@ -49,11 +49,13 @@ export struct URIConfigDialog {
       token.TokenName = labelParts[1];
 
       const parameters: Record<string, string> = {};
-      const query = otp_url.href.split('?')[1].toLowerCase();
+      const query = otp_url.href.split('?')[1];
       if (query) {
         query.split('&').forEach(part => {
           const kv: string[] = part.split('=');
-          parameters[kv[0]] = kv[1];
+          //保留secret的大小写
+          if(kv[0].toLowerCase()=='secret')parameters[kv[0].toLowerCase()] = kv[1];
+          else parameters[kv[0].toLowerCase()] = kv[1].toLowerCase();
         });
       }
       token.TokenSecret = parameters['secret'];


### PR DESCRIPTION
fix: 通过扫码或文本链接导入时，保持密钥大小写（虽然实际上不影响计算结果）