### PR TITLE
鸿蒙6.0 UI重做

### DIFF
--- a/entry/src/main/ets/components/SubItemIconManager.ets
+++ b/entry/src/main/ets/components/SubItemIconManager.ets
@@ -3,11 +3,12 @@ import { fileIo as fs } from '@kit.CoreFileKit';
 import { showSelectFilePicker } from '../utils/FileUtils';
 import { AegisIconPack, TokenIconPacks } from '../utils/TokenUtils';
 import { BusinessError, zlib } from '@kit.BasicServicesKit';
-import { AppStorageV2, promptAction } from '@kit.ArkUI';
+import { AppStorageV2 } from '@kit.ArkUI';
 import { SubItemDivider } from './SubItemDivider';
 import { AppPreference } from '../utils/AppPreference';
 import { AppWindowInfo } from '../entryability/EntryAbility';
 import { throttle,startBrowsableAbility } from '../utils/UiUtils';
+import { showSnackBar, SnackBarNotifyType } from '../utils/HdsSnackBarUtils';
 
 @Preview
 @ComponentV2
@@ -250,7 +251,7 @@ export struct SubItemIconManager {
                           fs.rmdir(out_path);
                         });
                       }).catch((reason: BusinessError) => {
-                        promptAction.showToast(reason);
+                        showSnackBar(reason.message ?? `${reason}`, SnackBarNotifyType.ERROR);
                         fs.close(fd.fd);
                       });
                     });

--- a/entry/src/main/ets/dialogs/FortiConfigDialog.ets
+++ b/entry/src/main/ets/dialogs/FortiConfigDialog.ets
@@ -4,7 +4,7 @@ import { http } from '@kit.NetworkKit';
 import { BusinessError } from '@kit.BasicServicesKit';
 import { cryptoFramework } from '@kit.CryptoArchitectureKit';
 import { buffer, util } from '@kit.ArkTS';
-import promptAction from '@ohos.promptAction'
+import { showSnackBar, SnackBarNotifyType } from '../utils/HdsSnackBarUtils';
 import { TokenIcon } from '../components/TokenIcon';
 import { SelectIconDialog } from './SelectIconDialog';
 
@@ -83,22 +83,22 @@ export struct FortiConfigDialog {
       });
     } catch (err) {
       this.btn_wait_from_forti = false;
-      promptAction.showToast({message: `Error: ${err.message}`})
+      showSnackBar(`Error: ${err.message}`, SnackBarNotifyType.ERROR);
     }
   }
 
   requestKeyFromForti(): void {
     if (this.conf.FortiToken.length !== 16) {
-      promptAction.showToast({ message: $r('app.string.toast_wrong_forti_token') })
+      showSnackBar($r('app.string.toast_wrong_forti_token'), SnackBarNotifyType.WARNING);
       return;
     }
     if (this.conf.FortiDevID.length !== 16) {
-      promptAction.showToast({ message: $r('app.string.toast_wrong_device_id') })
+      showSnackBar($r('app.string.toast_wrong_device_id'), SnackBarNotifyType.WARNING);
       return;
     }
     let raw_token = base32Decode(this.conf.FortiToken)
     if (!(raw_token[0] === 0x21)) {
-      promptAction.showToast({ message: $r('app.string.toast_wrong_user_token') })
+      showSnackBar($r('app.string.toast_wrong_user_token'), SnackBarNotifyType.WARNING);
       return;
     }
     this.btn_wait_from_forti = true;
@@ -133,7 +133,7 @@ export struct FortiConfigDialog {
           if (resp.d.error != undefined) {
             this.btn_wait_from_forti = false;
             console.error(`${resp.d.error.error_message}, code ${resp.d.error.error_code}`)
-            promptAction.showToast({ message: `${resp.d.error.error_message}, code ${resp.d.error.error_code}` })
+            showSnackBar(`${resp.d.error.error_message}, code ${resp.d.error.error_code}`, SnackBarNotifyType.ERROR);
           } else {
             this.decrypt_seed(resp.d.seed!)
             this.conf.TokenName = resp.d.issuer!
@@ -310,7 +310,7 @@ export struct FortiConfigDialog {
                 this.controller.close()
               }
             } else {
-              promptAction.showToast({ message: 'Enter a correct key' })
+              showSnackBar('Enter a correct key', SnackBarNotifyType.WARNING);
             }
           })
           .width('100%')

--- a/entry/src/main/ets/pages/Index.ets
+++ b/entry/src/main/ets/pages/Index.ets
@@ -588,7 +588,7 @@ struct Index {
         .layoutWeight(1)
         .barOverlap(true)
         .barBackgroundColor(Color.Transparent)
-        .barBackgroundBlurStyle(BlurStyle.Thin)
+        .barBackgroundBlurStyle(BlurStyle.Thick)
         .barPosition(BarPosition.End)
         .vertical(false)
         .barHeight(50 + this.window.AvoidBottomHeight)

--- a/entry/src/main/ets/pages/Index.ets
+++ b/entry/src/main/ets/pages/Index.ets
@@ -538,7 +538,10 @@ struct Index {
               normal: new SymbolGlyphModifier($r('sys.symbol.key')),
               selected: new SymbolGlyphModifier($r('sys.symbol.key_fill'))
             },
-            $r('app.string.tab_token')))
+            $r('app.string.tab_token'))
+            .verticalAlign(VerticalAlign.Top)
+            .padding({top: 10})
+          )
           .tabIndex(0)
 
           TabContent() {
@@ -578,9 +581,12 @@ struct Index {
           .tabBar(BottomTabBarStyle.of(
             {
               normal: new SymbolGlyphModifier($r('sys.symbol.gearshape')),
-              selected: new SymbolGlyphModifier($r('sys.symbol.gearshape_fill'))
+              selected: new SymbolGlyphModifier($r('sys.symbol.gearshape_fill')),
             },
-            $r('app.string.tab_setting')))
+            $r('app.string.tab_setting'))
+            .verticalAlign(VerticalAlign.Top)
+            .padding({top: 10})
+          )
           .tabIndex(1)
         }
         .barBackgroundColor($r('app.color.tab_bar_bg'))

--- a/entry/src/main/ets/pages/Index.ets
+++ b/entry/src/main/ets/pages/Index.ets
@@ -4,7 +4,7 @@ import { SettingPage } from '../pages/SettingPage'
 import { util } from '@kit.ArkTS';
 import { fileIo as fs } from '@kit.CoreFileKit';
 import { BusinessError, systemDateTime } from '@kit.BasicServicesKit';
-import promptAction from '@ohos.promptAction'
+import { showSnackBar, SnackBarNotifyType } from '../utils/HdsSnackBarUtils';
 import { AppPreference } from '../utils/AppPreference';
 import { privacyManager } from '@kit.StoreKit';
 import { hilog } from '@kit.PerformanceAnalysisKit';
@@ -317,7 +317,7 @@ struct Index {
   async updateTokenConfig(conf: TokenConfig, toast: boolean = true): Promise<void> {
     await tkStore.updateToken(conf);
     if (toast) {
-      promptAction.showToast({ message: $r('app.string.toast_token_update', conf.TokenIssuer, conf.TokenName) })
+      showSnackBar($r('app.string.toast_token_update', conf.TokenIssuer, conf.TokenName), SnackBarNotifyType.SUCCESS);
     }
   }
 
@@ -328,7 +328,7 @@ struct Index {
       }
       await this.updateTokenConfig(tokens[i], false);
     }
-    promptAction.showToast({ message: $r('app.string.toast_multi_token_update', tokens.length) })
+    showSnackBar($r('app.string.toast_multi_token_update', tokens.length), SnackBarNotifyType.SUCCESS);
   }
 
   // 准备接入标准化隐私托管

--- a/entry/src/main/ets/pages/Index.ets
+++ b/entry/src/main/ets/pages/Index.ets
@@ -462,7 +462,7 @@ struct Index {
                 normal: new SymbolGlyphModifier($r('sys.symbol.gearshape')),
                 selected: new SymbolGlyphModifier($r('sys.symbol.gearshape_fill'))
               },
-              $r('app.string.tab_token')))
+              $r('app.string.tab_setting')))
             .tabIndex(1)
           }
           .barBackgroundColor($r('app.color.tab_bar_bg'))
@@ -505,40 +505,32 @@ struct Index {
     }
     .titleMode(HdsNavigationTitleMode.MODAL)
     .titleBar({
+      avoidLayoutSafeArea: true, // 状态栏安全区沉浸
       style: {
         scrollEffectOpts: {
           enableScrollEffect: true,
-          scrollEffectType: ScrollEffectType.GRADIENT_BLUR
+          scrollEffectType: ScrollEffectType.COMMON_BLUR // 实时模糊，渐变是GRADIENT_BLUR
         }
       },
-      avoidLayoutSafeArea: true,
       content: {
         title: {
           mainTitle: $r('app.string.EntryAbility_label')
         },
         menu: {
-          value: [{
-            content: {
-              label: 'add',
-              icon: $r('sys.symbol.plus'),
-              isEnabled: true,
-              action: () => {
-                //TODO: 蓝的添加按钮功能
+          value: [
+            {
+              content: {
+                label: $r('app.string.app_ua_search_token'),
+                icon: $r('sys.symbol.magnifyingglass'),
+                isEnabled: true,
+                action: () => {
+                  //TODO: 下拉搜索触发改成这里触发
+                }
               }
             }
-          }, {
-            content: {
-              label: 'search',
-              icon: $r('sys.symbol.magnifyingglass'),
-              isEnabled: true,
-              action: () => {
-                //TODO: 下拉搜索触发改成这里触发
-              }
-            }
-          }]
+          ]
         }
       }
     })
   }
-
 }

--- a/entry/src/main/ets/pages/Index.ets
+++ b/entry/src/main/ets/pages/Index.ets
@@ -20,7 +20,8 @@ import { TokenIconPacks } from '../utils/TokenUtils';
 import { screenLockFileManager } from '@kit.AbilityKit';
 import { TokenListPage } from './TokenListPage';
 import { AppWindowInfo } from '../entryability/EntryAbility';
-import { AppStorageV2, ArcButton, ArcList, ArcListItem, router, window } from '@kit.ArkUI';
+import { AppStorageV2, router, SymbolGlyphModifier, window } from '@kit.ArkUI';
+import { HdsTabs } from '@kit.UIDesignKit';
 import { ArcTokenListPage } from './ArcTokenListPage';
 
 const TAG = 'PrivacySubscribe';
@@ -372,18 +373,6 @@ struct Index {
     });
   }
 
-  @Builder
-  tabBar(text: ResourceStr | string, id: number) {
-    Column(){
-      Blank()
-        .width('100%')
-        .height(this.window.AvoidTopHeight)
-      Text(text)
-        .fontWeight(this.tab_bar_index === id ? 500 : 400)
-        .fontColor(this.tab_bar_index === id ? $r('app.color.token_number') : $r('app.color.str_main'))
-    }
-  }
-
   build() {
     Stack() {
       if (this.token_loading) {
@@ -433,7 +422,7 @@ struct Index {
       } else {
 
         Column() {
-          Tabs({ index: this.tab_bar_index }) {
+          HdsTabs({ index: this.tab_bar_index }) {
             TabContent() {
               TokenListPage({
                 Tokens: this.CurrentTokens,
@@ -446,7 +435,12 @@ struct Index {
               })
             }
             .backgroundColor($r('app.color.window_background'))
-            .tabBar(this.tabBar($r('app.string.tab_token'), 0))
+            .tabBar(BottomTabBarStyle.of(
+              {
+                normal: new SymbolGlyphModifier($r('sys.symbol.key')),
+                selected: new SymbolGlyphModifier($r('sys.symbol.key_fill'))
+              },
+              $r('app.string.tab_token')))
             .tabIndex(0)
 
             TabContent() {
@@ -462,7 +456,12 @@ struct Index {
                 .height('100%')
             }
             .backgroundColor($r('app.color.window_background'))
-            .tabBar(this.tabBar($r('app.string.tab_setting'), 1))
+            .tabBar(BottomTabBarStyle.of(
+              {
+                normal: new SymbolGlyphModifier($r('sys.symbol.gearshape')),
+                selected: new SymbolGlyphModifier($r('sys.symbol.gearshape_fill'))
+              },
+              $r('app.string.tab_token')))
             .tabIndex(1)
           }
           .barBackgroundColor($r('app.color.tab_bar_bg'))
@@ -471,7 +470,9 @@ struct Index {
           .barOverlap(true)
           .barBackgroundColor(Color.Transparent)
           .barBackgroundBlurStyle(BlurStyle.Thin)
-          .barHeight(50 + this.window.AvoidTopHeight)
+          .barPosition(BarPosition.End)
+          .vertical(false)
+          .barHeight(50 + this.window.AvoidBottomHeight)
           .barMode(BarMode.Fixed)
           .onChange((index) => {
             this.tab_bar_index = index;

--- a/entry/src/main/ets/pages/Index.ets
+++ b/entry/src/main/ets/pages/Index.ets
@@ -21,7 +21,8 @@ import { screenLockFileManager } from '@kit.AbilityKit';
 import { TokenListPage } from './TokenListPage';
 import { AppWindowInfo } from '../entryability/EntryAbility';
 import { AppStorageV2, router, SymbolGlyphModifier, window } from '@kit.ArkUI';
-import { HdsNavigation, HdsNavigationTitleMode, HdsTabs, ScrollEffectType } from '@kit.UIDesignKit';
+import { HdsNavigation, HdsTabsAttribute, HdsNavigationTitleMode, HdsTabs,
+  ScrollEffectType } from '@kit.UIDesignKit';
 import { ArcTokenListPage } from './ArcTokenListPage';
 
 const TAG = 'PrivacySubscribe';
@@ -374,25 +375,25 @@ struct Index {
   }
 
   build() {
-    HdsNavigation() {
-      Stack() {
-        if (this.token_loading) {
-          Column() {
-            LoadingProgress()
-              .color(Color.White)
-            .width(80).height(80)
-          Text('Loading..')
-            .fontSize(16)
-            .fontColor(Color.White)
-        }
-        .width('100%')
-        .height('100%')
-        .backgroundColor('#40000000')
-        .justifyContent(FlexAlign.Center)
-      } else if (
-        (this.window.HeightBreakpoint === HeightBreakpoint.HEIGHT_MD) &&
-          this.window.WidthBreakpoint === WidthBreakpoint.WIDTH_XS
-      ) {
+    Stack() {
+      if (this.token_loading) {
+        Column() {
+          LoadingProgress()
+            .color(Color.White)
+          .width(80).height(80)
+        Text('Loading..')
+          .fontSize(16)
+          .fontColor(Color.White)
+      }
+      .width('100%')
+      .height('100%')
+      .backgroundColor('#40000000')
+      .justifyContent(FlexAlign.Center)
+    } else if (
+      (this.window.HeightBreakpoint === HeightBreakpoint.HEIGHT_MD) &&
+        this.window.WidthBreakpoint === WidthBreakpoint.WIDTH_XS
+    ) {
+      HdsNavigation() {
         ArcTokenListPage({
           Tokens: this.CurrentTokens,
           TabBarVisible: false,
@@ -402,11 +403,43 @@ struct Index {
           updateTokenConfig: this.updateTokenConfig,
           updateTokenConfigs: this.updateTokenConfigs,
         })
-      } else if (
-        (this.window.HeightBreakpoint === HeightBreakpoint.HEIGHT_MD ||
-          this.window.HeightBreakpoint === HeightBreakpoint.HEIGHT_SM) &&
-          this.window.WidthBreakpoint === WidthBreakpoint.WIDTH_SM
-      ) {
+      }
+      .titleMode(HdsNavigationTitleMode.MODAL)
+      .titleBar({
+        avoidLayoutSafeArea: true, // 状态栏安全区沉浸
+        style: {
+          scrollEffectOpts: {
+            enableScrollEffect: true,
+            scrollEffectType: ScrollEffectType.COMMON_BLUR // 实时模糊，渐变是GRADIENT_BLUR
+            // scrollEffectType: ScrollEffectType.GRADIENT_BLUR // 实时模糊，渐变是GRADIENT_BLUR
+          }
+        },
+        content: {
+          title: {
+            mainTitle: $r('app.string.EntryAbility_label')
+          },
+          menu: {
+            value: [
+              {
+                content: {
+                  label: $r('app.string.app_ua_search_token'),
+                  icon: $r('sys.symbol.magnifyingglass'),
+                  isEnabled: true,
+                  action: () => {
+                    //TODO: 下拉搜索触发改成这里触发
+                  }
+                }
+              }
+            ]
+          }
+        }
+      })
+    } else if (
+      (this.window.HeightBreakpoint === HeightBreakpoint.HEIGHT_MD ||
+        this.window.HeightBreakpoint === HeightBreakpoint.HEIGHT_SM) &&
+        this.window.WidthBreakpoint === WidthBreakpoint.WIDTH_SM
+    ) {
+      HdsNavigation() {
         Column() {
           TokenListPage({
             Tokens: this.CurrentTokens,
@@ -420,11 +453,44 @@ struct Index {
         }
         .backgroundColor($r('app.color.window_background'))
 
-      } else {
+      }
+      .titleMode(HdsNavigationTitleMode.MODAL)
+      .titleBar({
+        avoidLayoutSafeArea: true, // 状态栏安全区沉浸
+        style: {
+          scrollEffectOpts: {
+            enableScrollEffect: true,
+            scrollEffectType: ScrollEffectType.COMMON_BLUR // 实时模糊，渐变是GRADIENT_BLUR
+            // scrollEffectType: ScrollEffectType.GRADIENT_BLUR // 实时模糊，渐变是GRADIENT_BLUR
+          }
+        },
+        content: {
+          title: {
+            mainTitle: $r('app.string.EntryAbility_label')
+          },
+          menu: {
+            value: [
+              {
+                content: {
+                  label: $r('app.string.app_ua_search_token'),
+                  icon: $r('sys.symbol.magnifyingglass'),
+                  isEnabled: true,
+                  action: () => {
+                    //TODO: 下拉搜索触发改成这里触发
+                  }
+                }
+              }
+            ]
+          }
+        }
+      })
 
-        Column() {
-          HdsTabs({ index: this.tab_bar_index }) {
-            TabContent() {
+    } else {
+
+      Column() {
+        HdsTabs({ index: this.tab_bar_index }) {
+          TabContent() {
+            HdsNavigation() {
               TokenListPage({
                 Tokens: this.CurrentTokens,
                 TabBarVisible: true,
@@ -435,16 +501,48 @@ struct Index {
                 updateTokenConfigs: this.updateTokenConfigs,
               })
             }
-            .backgroundColor($r('app.color.window_background'))
-            .tabBar(BottomTabBarStyle.of(
-              {
-                normal: new SymbolGlyphModifier($r('sys.symbol.key')),
-                selected: new SymbolGlyphModifier($r('sys.symbol.key_fill'))
+            .titleMode(HdsNavigationTitleMode.MODAL)
+            .titleBar({
+              avoidLayoutSafeArea: true, // 状态栏安全区沉浸
+              style: {
+                scrollEffectOpts: {
+                  enableScrollEffect: true,
+                  scrollEffectType: ScrollEffectType.COMMON_BLUR // 实时模糊，渐变是GRADIENT_BLUR
+                  // scrollEffectType: ScrollEffectType.GRADIENT_BLUR // 实时模糊，渐变是GRADIENT_BLUR
+                }
               },
-              $r('app.string.tab_token')))
-            .tabIndex(0)
+              content: {
+                title: {
+                  mainTitle: $r('app.string.EntryAbility_label'),
+                },
+                menu: {
+                  value: [
+                    {
+                      content: {
+                        label: $r('app.string.app_ua_search_token'),
+                        icon: $r('sys.symbol.magnifyingglass'),
+                        isEnabled: true,
+                        action: () => {
+                          //TODO: 下拉搜索触发改成这里触发
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            })
+          }
+          .backgroundColor($r('app.color.window_background'))
+          .tabBar(BottomTabBarStyle.of(
+            {
+              normal: new SymbolGlyphModifier($r('sys.symbol.key')),
+              selected: new SymbolGlyphModifier($r('sys.symbol.key_fill'))
+            },
+            $r('app.string.tab_token')))
+          .tabIndex(0)
 
-            TabContent() {
+          TabContent() {
+            HdsNavigation() {
               SettingPage({
                 Tokens: this.CurrentTokens,
                 appBottomAvoidHeight: this.window.AvoidBottomHeight,
@@ -456,81 +554,71 @@ struct Index {
               })
                 .height('100%')
             }
-            .backgroundColor($r('app.color.window_background'))
-            .tabBar(BottomTabBarStyle.of(
-              {
-                normal: new SymbolGlyphModifier($r('sys.symbol.gearshape')),
-                selected: new SymbolGlyphModifier($r('sys.symbol.gearshape_fill'))
+            .titleMode(HdsNavigationTitleMode.MODAL)
+            .titleBar({
+              avoidLayoutSafeArea: true, // 状态栏安全区沉浸
+              style: {
+                scrollEffectOpts: {
+                  enableScrollEffect: true,
+                  scrollEffectType: ScrollEffectType.COMMON_BLUR // 实时模糊，渐变是GRADIENT_BLUR
+                  // scrollEffectType: ScrollEffectType.GRADIENT_BLUR // 实时模糊，渐变是GRADIENT_BLUR
+                }
               },
-              $r('app.string.tab_setting')))
-            .tabIndex(1)
-          }
-          .barBackgroundColor($r('app.color.tab_bar_bg'))
-          .backgroundColor($r('app.color.window_background'))
-          .layoutWeight(1)
-          .barOverlap(true)
-          .barBackgroundColor(Color.Transparent)
-          .barBackgroundBlurStyle(BlurStyle.Thin)
-          .barPosition(BarPosition.End)
-          .vertical(false)
-          .barHeight(50 + this.window.AvoidBottomHeight)
-          .barMode(BarMode.Fixed)
-          .onChange((index) => {
-            this.tab_bar_index = index;
-          })
-        }
-        }
-      }
-      .width('100%')
-      .height('100%')
-      .allowDrop([uniformTypeDescriptor.UniformDataType.FILE])
-      .onDrop(() => {
-        this.DropFilesDialogIsOpen = false;
-        this.DropFilesDialogController?.close();
-      })
-      .onDragEnter(() => {
-        if (!this.DropFilesDialogIsOpen) {
-          this.DropFilesDialogIsOpen = true;
-          this.DropFilesDialogController?.open();
-        }
-      })
-      .onDragLeave(() => {
-        this.DropFilesDialogIsOpen = false;
-        this.DropFilesDialogController?.close();
-      })
-      .foregroundBlurStyle(this.background_blur_flag ? BlurStyle.Thin : BlurStyle.NONE, {
-        colorMode: ThemeColorMode.SYSTEM,
-        adaptiveColor: AdaptiveColor.DEFAULT
-      })
-    }
-    .titleMode(HdsNavigationTitleMode.MODAL)
-    .titleBar({
-      avoidLayoutSafeArea: true, // 状态栏安全区沉浸
-      style: {
-        scrollEffectOpts: {
-          enableScrollEffect: true,
-          scrollEffectType: ScrollEffectType.COMMON_BLUR // 实时模糊，渐变是GRADIENT_BLUR
-        }
-      },
-      content: {
-        title: {
-          mainTitle: $r('app.string.EntryAbility_label')
-        },
-        menu: {
-          value: [
-            {
               content: {
-                label: $r('app.string.app_ua_search_token'),
-                icon: $r('sys.symbol.magnifyingglass'),
-                isEnabled: true,
-                action: () => {
-                  //TODO: 下拉搜索触发改成这里触发
+                title: {
+                  mainTitle: $r('app.string.tab_setting')
+                },
+                menu: {
+                  value: []
                 }
               }
-            }
-          ]
+            })
+          }
+          .backgroundColor($r('app.color.window_background'))
+          .tabBar(BottomTabBarStyle.of(
+            {
+              normal: new SymbolGlyphModifier($r('sys.symbol.gearshape')),
+              selected: new SymbolGlyphModifier($r('sys.symbol.gearshape_fill'))
+            },
+            $r('app.string.tab_setting')))
+          .tabIndex(1)
         }
+        .barBackgroundColor($r('app.color.tab_bar_bg'))
+        .backgroundColor($r('app.color.window_background'))
+        .layoutWeight(1)
+        .barOverlap(true)
+        .barBackgroundColor(Color.Transparent)
+        .barBackgroundBlurStyle(BlurStyle.Thin)
+        .barPosition(BarPosition.End)
+        .vertical(false)
+        .barHeight(50 + this.window.AvoidBottomHeight)
+        .barMode(BarMode.Fixed)
+        .onChange((index) => {
+          this.tab_bar_index = index;
+        })
       }
+      }
+    }
+    .width('100%')
+    .height('100%')
+    .allowDrop([uniformTypeDescriptor.UniformDataType.FILE])
+    .onDrop(() => {
+      this.DropFilesDialogIsOpen = false;
+      this.DropFilesDialogController?.close();
+    })
+    .onDragEnter(() => {
+      if (!this.DropFilesDialogIsOpen) {
+        this.DropFilesDialogIsOpen = true;
+        this.DropFilesDialogController?.open();
+      }
+    })
+    .onDragLeave(() => {
+      this.DropFilesDialogIsOpen = false;
+      this.DropFilesDialogController?.close();
+    })
+    .foregroundBlurStyle(this.background_blur_flag ? BlurStyle.Thin : BlurStyle.NONE, {
+      colorMode: ThemeColorMode.SYSTEM,
+      adaptiveColor: AdaptiveColor.DEFAULT
     })
   }
 }

--- a/entry/src/main/ets/pages/Index.ets
+++ b/entry/src/main/ets/pages/Index.ets
@@ -21,7 +21,7 @@ import { screenLockFileManager } from '@kit.AbilityKit';
 import { TokenListPage } from './TokenListPage';
 import { AppWindowInfo } from '../entryability/EntryAbility';
 import { AppStorageV2, router, SymbolGlyphModifier, window } from '@kit.ArkUI';
-import { HdsTabs } from '@kit.UIDesignKit';
+import { HdsNavigation, HdsNavigationTitleMode, HdsTabs, ScrollEffectType } from '@kit.UIDesignKit';
 import { ArcTokenListPage } from './ArcTokenListPage';
 
 const TAG = 'PrivacySubscribe';
@@ -374,11 +374,12 @@ struct Index {
   }
 
   build() {
-    Stack() {
-      if (this.token_loading) {
-        Column() {
-          LoadingProgress()
-            .color(Color.White)
+    HdsNavigation() {
+      Stack() {
+        if (this.token_loading) {
+          Column() {
+            LoadingProgress()
+              .color(Color.White)
             .width(80).height(80)
           Text('Loading..')
             .fontSize(16)
@@ -478,28 +479,65 @@ struct Index {
             this.tab_bar_index = index;
           })
         }
+        }
       }
+      .width('100%')
+      .height('100%')
+      .allowDrop([uniformTypeDescriptor.UniformDataType.FILE])
+      .onDrop(() => {
+        this.DropFilesDialogIsOpen = false;
+        this.DropFilesDialogController?.close();
+      })
+      .onDragEnter(() => {
+        if (!this.DropFilesDialogIsOpen) {
+          this.DropFilesDialogIsOpen = true;
+          this.DropFilesDialogController?.open();
+        }
+      })
+      .onDragLeave(() => {
+        this.DropFilesDialogIsOpen = false;
+        this.DropFilesDialogController?.close();
+      })
+      .foregroundBlurStyle(this.background_blur_flag ? BlurStyle.Thin : BlurStyle.NONE, {
+        colorMode: ThemeColorMode.SYSTEM,
+        adaptiveColor: AdaptiveColor.DEFAULT
+      })
     }
-    .width('100%')
-    .height('100%')
-    .allowDrop([uniformTypeDescriptor.UniformDataType.FILE])
-    .onDrop(() => {
-      this.DropFilesDialogIsOpen = false;
-      this.DropFilesDialogController?.close();
-    })
-    .onDragEnter(() => {
-      if (!this.DropFilesDialogIsOpen) {
-        this.DropFilesDialogIsOpen = true;
-        this.DropFilesDialogController?.open();
+    .titleMode(HdsNavigationTitleMode.MODAL)
+    .titleBar({
+      style: {
+        scrollEffectOpts: {
+          enableScrollEffect: true,
+          scrollEffectType: ScrollEffectType.GRADIENT_BLUR
+        }
+      },
+      avoidLayoutSafeArea: true,
+      content: {
+        title: {
+          mainTitle: $r('app.string.EntryAbility_label')
+        },
+        menu: {
+          value: [{
+            content: {
+              label: 'add',
+              icon: $r('sys.symbol.plus'),
+              isEnabled: true,
+              action: () => {
+                //TODO: 蓝的添加按钮功能
+              }
+            }
+          }, {
+            content: {
+              label: 'search',
+              icon: $r('sys.symbol.magnifyingglass'),
+              isEnabled: true,
+              action: () => {
+                //TODO: 下拉搜索触发改成这里触发
+              }
+            }
+          }]
+        }
       }
-    })
-    .onDragLeave(() => {
-      this.DropFilesDialogIsOpen = false;
-      this.DropFilesDialogController?.close();
-    })
-    .foregroundBlurStyle(this.background_blur_flag ? BlurStyle.Thin : BlurStyle.NONE, {
-      colorMode: ThemeColorMode.SYSTEM,
-      adaptiveColor: AdaptiveColor.DEFAULT
     })
   }
 

--- a/entry/src/main/ets/pages/Index.ets
+++ b/entry/src/main/ets/pages/Index.ets
@@ -594,7 +594,7 @@ struct Index {
         .layoutWeight(1)
         .barOverlap(true)
         .barBackgroundColor(Color.Transparent)
-        .barBackgroundBlurStyle(BlurStyle.Thick)
+        .barBackgroundBlurStyle(BlurStyle.Regular)
         .barPosition(BarPosition.End)
         .vertical(false)
         .barHeight(50 + this.window.AvoidBottomHeight)

--- a/entry/src/main/ets/pages/MasterKeyPage.ets
+++ b/entry/src/main/ets/pages/MasterKeyPage.ets
@@ -10,6 +10,7 @@ import { showSaveFilePicker, showSelectFilePicker, writeFileContent,
   writeFileContentCheckHashEqual } from '../utils/FileUtils';
 import lottie, { AnimationItem } from '@ohos/lottie';
 import { throttle } from '../utils/UiUtils';
+import { showSnackBar, SnackBarNotifyType } from '../utils/HdsSnackBarUtils';
 
 
 @Entry
@@ -62,13 +63,13 @@ struct MasterKeyPage {
       }
       else
       {
-        this.getUIContext().getPromptAction().showToast({ message: $r('app.string.restore_master_key_password_too_short_msg'), bottom: this.TOAST_BOTTOM })
+        showSnackBar($r('app.string.restore_master_key_password_too_short_msg'), SnackBarNotifyType.WARNING);
       }
     }
   }
   confirmRecoveryKey(){
     //this.tkStore.CheckRecoverySecretKey(this.recoverySecretKey).then((b)=>{
-    //  this.getUIContext().getPromptAction().showToast({ message: b?"恢复密钥OK":"恢复密钥Err", bottom: this.TOAST_BOTTOM })
+    //  showSnackBar(b ? "恢复密钥OK" : "恢复密钥Err", SnackBarNotifyType.INFO)
     //})
     //this.appCtx?.eventHub.emit('onMasterKeyPageBack');
     router.back();
@@ -77,7 +78,7 @@ struct MasterKeyPage {
     showSaveFilePicker([`totp_recovery_key.text`], ['Text|.text']).then((uris) => {
       if (uris[0] !== undefined && uris[0] !== '') {
         writeFileContentCheckHashEqual(uris[0], this.recoverySecretKey).then(()=>{
-          this.getUIContext().getPromptAction().showToast({ message: "OK", bottom: this.TOAST_BOTTOM })
+          showSnackBar('OK', SnackBarNotifyType.SUCCESS);
         });
       }
     });

--- a/entry/src/main/ets/pages/RecoveryKeyRecordPage.ets
+++ b/entry/src/main/ets/pages/RecoveryKeyRecordPage.ets
@@ -10,6 +10,7 @@ import { showSaveFilePicker, showSelectFilePicker, writeFileContent,
   writeFileContentCheckHashEqual } from '../utils/FileUtils';
 import lottie, { AnimationItem } from '@ohos/lottie';
 import { throttle } from '../utils/UiUtils';
+import { showSnackBar, SnackBarNotifyType } from '../utils/HdsSnackBarUtils';
 
 
 @Entry
@@ -41,7 +42,7 @@ struct RecoveryKeyRecordPage {
   }
   confirmRecoveryKey(){
     //this.tkStore.CheckRecoverySecretKey(this.recoverySecretKey).then((b)=>{
-    //  this.getUIContext().getPromptAction().showToast({ message: b?"恢复密钥OK":"恢复密钥Err", bottom: this.TOAST_BOTTOM })
+    //  showSnackBar(b ? "恢复密钥OK" : "恢复密钥Err", SnackBarNotifyType.INFO)
     //})
     //this.appCtx?.eventHub.emit('onMasterKeyPageBack');
     router.back({ url: 'pages/Index' });
@@ -50,7 +51,7 @@ struct RecoveryKeyRecordPage {
     showSaveFilePicker([`totp_recovery_key.text`], ['Text|.text']).then((uris) => {
       if (uris[0] !== undefined && uris[0] !== '') {
         writeFileContentCheckHashEqual(uris[0], this.recoverySecretKey).then(()=>{
-          this.getUIContext().getPromptAction().showToast({ message: "OK", bottom: this.TOAST_BOTTOM })
+          showSnackBar('OK', SnackBarNotifyType.SUCCESS);
         });
       }
     });

--- a/entry/src/main/ets/pages/RestoreDataPage.ets
+++ b/entry/src/main/ets/pages/RestoreDataPage.ets
@@ -9,6 +9,7 @@ import { hilog } from '@kit.PerformanceAnalysisKit';
 import { throttle } from '../utils/UiUtils';
 import { showSelectFilePicker, readFileContentAndCheckSize } from '../utils/FileUtils';
 import { fileIo as fs } from "@kit.CoreFileKit";
+import { showSnackBar, SnackBarNotifyType } from '../utils/HdsSnackBarUtils';
 
 
 @Entry
@@ -102,7 +103,7 @@ struct RestoreDataPage {
       this.isBegin = false;
       this.progress = 0;
       this.isRestoreSuccess=false;
-      //this.getUIContext().getPromptAction().showToast({ message: $r('app.string.restore_data_ok_msg'), bottom: this.TOAST_BOTTOM })
+      //showSnackBar($r('app.string.restore_data_ok_msg'), SnackBarNotifyType.SUCCESS)
       this.getUIContext().showAlertDialog(
         {
           title: $r(title),
@@ -138,7 +139,7 @@ struct RestoreDataPage {
         this.recoveryKey=text;
         this.recoveryKeyShow=text;
         if (text=="") {
-          this.getUIContext().getPromptAction().showToast({ message: "invalid Recovery Key file", bottom: this.TOAST_BOTTOM })
+          showSnackBar('invalid Recovery Key file', SnackBarNotifyType.ERROR);
         }
       });
     });

--- a/entry/src/main/ets/pages/SettingPage.ets
+++ b/entry/src/main/ets/pages/SettingPage.ets
@@ -280,7 +280,7 @@ export struct SettingPage {
             ListItem() {
 
             }
-            .height(50 + this.appTopAvoidHeight)
+            .height(60 + this.appTopAvoidHeight)
           }
 
           ListItem() {
@@ -626,7 +626,7 @@ export struct SettingPage {
             ListItem() {
               Row()
                 .width('100%')
-                .height(this.appBottomAvoidHeight)
+                .height(this.appBottomAvoidHeight + 60)
             }
           }
         }

--- a/entry/src/main/ets/pages/SettingPage.ets
+++ b/entry/src/main/ets/pages/SettingPage.ets
@@ -2,7 +2,7 @@ import { TokenConfig } from '../utils/TokenConfig';
 import { BusinessError } from '@kit.BasicServicesKit';
 import { bundleManager, common, ConfigurationConstant } from '@kit.AbilityKit';
 import { convertToken2URI, generateFileNameWithDate } from '../utils/TokenUtils'
-import promptAction from '@ohos.promptAction'
+import { showSnackBar, SnackBarNotifyType } from '../utils/HdsSnackBarUtils';
 import { SubItemToggle } from '../components/SubItemToggle'
 import { AppStorageV2, curves, router } from '@kit.ArkUI';
 import { AppPreference, SettingColorMode, SettingValue, TokenPreference } from '../utils/AppPreference';
@@ -96,11 +96,11 @@ export struct SettingPage {
           showSaveFilePicker([`totp_backup_${generateFileNameWithDate()}.bak`], ['BAK|.bak']).then((uris) => {
             const backup: TokenBackup = new TokenBackup(this.versionCode ?? 0, this.Tokens);
             if (uris[0] !== undefined && uris[0] !== '') {
-              saveBackupToFile(uris[0], backup, true, password).then(() => {
-                promptAction.showToast({ message: $r('app.string.toast_backup_success') });
-              }).catch((reason: BusinessError) => {
-                promptAction.showToast({ message: reason.message });
-              });
+                  saveBackupToFile(uris[0], backup, true, password).then(() => {
+                    showSnackBar($r('app.string.toast_backup_success'), SnackBarNotifyType.SUCCESS);
+                  }).catch((reason: BusinessError) => {
+                    showSnackBar(reason.message, SnackBarNotifyType.ERROR);
+                  });
             }
           });
         } else { // 加密导入
@@ -199,9 +199,9 @@ export struct SettingPage {
                 const backup: TokenBackup = new TokenBackup(this.versionCode, this.Tokens);
                 if (uris[0] !== undefined && uris[0] !== '') {
                   saveBackupToFile(uris[0], backup).then(() => {
-                    promptAction.showToast({ message: $r('app.string.toast_backup_success') });
+                    showSnackBar($r('app.string.toast_backup_success'), SnackBarNotifyType.SUCCESS);
                   }).catch((reason: BusinessError) => {
-                    promptAction.showToast({ message: reason.message });
+                    showSnackBar(reason.message, SnackBarNotifyType.ERROR);
                   });
                 }
               });
@@ -377,7 +377,7 @@ export struct SettingPage {
                       userAuth.getAvailableStatus(userAuth.UserAuthType.PIN, userAuth.AuthTrustLevel.ATL1);
                     } catch (err) {
                       const error = err as BusinessError;
-                      promptAction.showToast({ message: error.message });
+                      showSnackBar(error.message, SnackBarNotifyType.ERROR);
                       return;
                     }
                   }
@@ -585,11 +585,11 @@ export struct SettingPage {
                 this.debug_mode_counter = 0;
               }, 2000);
               if (this.debug_mode_counter > 7) {
-                this.window.uiContext?.animateTo({ curve: curves.springMotion() }, () => {
-                  this.debug_mode_is_on = true;
-                  AppPreference.setPreference('app_debug_mode_on', true);
-                  promptAction.showToast({ message: "DEBUG MODE ON" });
-                })
+                  this.window.uiContext?.animateTo({ curve: curves.springMotion() }, () => {
+                    this.debug_mode_is_on = true;
+                    AppPreference.setPreference('app_debug_mode_on', true);
+                    showSnackBar('DEBUG MODE ON', SnackBarNotifyType.INFO);
+                  })
 
               }
               this.debug_mode_counter++;

--- a/entry/src/main/ets/pages/TokenListPage.ets
+++ b/entry/src/main/ets/pages/TokenListPage.ets
@@ -248,12 +248,16 @@ export struct TokenListPage {
               baseIcon: $r('sys.symbol.plus'),
               hoverTips: $r('app.string.app_ua_add_token'),
               accessibilityText: $r('app.string.app_ua_add_token'),
+              onClick: () => {
+                this.isExpand = !this.isExpand;
+              }
             })],
             endButtons: [new ActionBarButton({
               baseIcon: $r('sys.symbol.line_viewfinder'),
               hoverTips: $r('app.string.app_scan_code'),
               accessibilityText: $r('app.string.app_scan_code'),
               onClick: () => {
+                this.isExpand = !this.isExpand;
                 this.start_quick_scan();
               }
             })],
@@ -269,7 +273,7 @@ export struct TokenListPage {
               }
             }),
             actionBarStyle: new ActionBarStyle({
-              isPrimaryIconChanged: this.isPrimaryIconChanged
+              isPrimaryIconChanged: this.isPrimaryIconChanged,
             }),
             isExpand: this.isExpand
           })

--- a/entry/src/main/ets/pages/TokenListPage.ets
+++ b/entry/src/main/ets/pages/TokenListPage.ets
@@ -93,7 +93,7 @@ export struct TokenListPage {
               Column() {
                 if (this.TabBarVisible) {
                   Row()
-                    .height(50 + this.appTopAvoidHeight)
+                    .height(60 + this.appTopAvoidHeight)
                     .width('100%')
                 } else {
                   Row()
@@ -203,6 +203,13 @@ export struct TokenListPage {
                 setTimeout(() => tkStore.updateTokenRank(from, to), 500);
               }
             })
+
+          ListItem() {
+            Row()
+              .height(this.TabBarVisible ? (50 + this.appBottomAvoidHeight) : (20 + this.appBottomAvoidHeight))
+              .width('100%')
+          }
+          .selectable(false)
         }
         .alignListItem(ListItemAlign.Center)
         .lanes({minLength: 400, maxLength: this.token_preference.app_appearance_item_max_width})
@@ -266,11 +273,12 @@ export struct TokenListPage {
             }),
             isExpand: this.isExpand
           })
-            .bindMenu(this.TokenAddMenu(), { placement: Placement.BottomRight })
+            // .bindMenu(this.TokenAddMenu(), { placement: Placement.BottomRight })
         }
         .width('100%')
         .justifyContent(FlexAlign.Center)
         .margin({ bottom: this.appBottomAvoidHeight + 35 })
+        .hitTestBehavior(HitTestMode.None)
       }
     }
   }

--- a/entry/src/main/ets/pages/TokenListPage.ets
+++ b/entry/src/main/ets/pages/TokenListPage.ets
@@ -7,7 +7,8 @@ import { AppPreference, SettingValue, TokenPreference } from "../utils/AppPrefer
 import { otpType, TokenConfig } from "../utils/TokenConfig";
 import { TokenStore } from "../utils/TokenStore";
 import { convertToken2URI, ScanBarCode } from "../utils/TokenUtils";
-import { AppStorageV2, curves, window } from "@kit.ArkUI";
+import { AppStorageV2, ComponentContent, curves, window } from "@kit.ArkUI";
+import { ActionBarButton, ActionBarStyle, HdsActionBar } from "@kit.UIDesignKit";
 import { url } from "@kit.ArkTS";
 import { decodeProtobuf } from "../utils/GoogleAuthUtils";
 import { URIConfigDialog } from "../dialogs/URIConfigDialog";
@@ -40,9 +41,9 @@ export struct TokenListPage {
   @Local token_list_search_str: string = '';
   @Local id_list: string[] = ['search_bar'];
 
-  @Local btn_token_add_clicked: number = 0;
-
-  private plus_btn_height: number = 70;
+  @Local isExpand: boolean = false;
+  @Local isPrimaryIconChanged: boolean = false;
+  @Local primaryHoverTips: string = '收起';
 
   private dialog_uri_config?: CustomDialogController;
   private dialog_totp_config?: CustomDialogController;
@@ -71,7 +72,7 @@ export struct TokenListPage {
   }
 
   build() {
-    Stack({ alignContent: Alignment.BottomEnd }) {
+    Stack({ alignContent: Alignment.Bottom }) {
       if (this.Tokens.length === 0) {
         Row() {
           Text(this.token_list_search_enable ? $r('app.string.app_token_list_search_msg') :
@@ -202,20 +203,6 @@ export struct TokenListPage {
                 setTimeout(() => tkStore.updateTokenRank(from, to), 500);
               }
             })
-          ListItemGroup() {
-            ListItem() {
-              if (this.TabBarVisible) {
-                Row()
-                  .width('100%')
-                  .height(this.appBottomAvoidHeight > this.plus_btn_height ? this.appBottomAvoidHeight : this.plus_btn_height)
-              } else {
-                Row()
-                  .width('100%')
-                  .height(this.appBottomAvoidHeight)
-              }
-
-            }
-          }
         }
         .alignListItem(ListItemAlign.Center)
         .lanes({minLength: 400, maxLength: this.token_preference.app_appearance_item_max_width})
@@ -248,24 +235,42 @@ export struct TokenListPage {
         })
       }
       if (this.TabBarVisible) {
-        Button({ type: ButtonType.Circle }) {
-          SymbolGlyph($r('sys.symbol.plus'))
-            .fontSize(40)
-            .fontWeight(FontWeight.Bold)
-            .fontColor([Color.White])
-            .symbolEffect(new BounceSymbolEffect(EffectScope.WHOLE, EffectDirection.UP),
-              this.btn_token_add_clicked)
+        Row() {
+          HdsActionBar({
+            startButtons: [new ActionBarButton({
+              baseIcon: $r('sys.symbol.plus'),
+              hoverTips: $r('app.string.app_ua_add_token'),
+              accessibilityText: $r('app.string.app_ua_add_token'),
+            })],
+            endButtons: [new ActionBarButton({
+              baseIcon: $r('sys.symbol.line_viewfinder'),
+              hoverTips: $r('app.string.app_scan_code'),
+              accessibilityText: $r('app.string.app_scan_code'),
+              onClick: () => {
+                this.start_quick_scan();
+              }
+            })],
+            primaryButton: new ActionBarButton({
+              baseIcon: $r('sys.symbol.plus'),
+              altIcon: $r('sys.symbol.xmark'),
+              hoverTips: this.primaryHoverTips,
+              accessibilityText: this.primaryHoverTips,
+              onClick: () => {
+                this.isExpand = !this.isExpand;
+                this.isPrimaryIconChanged = !this.isPrimaryIconChanged;
+                this.primaryHoverTips = this.isExpand ? '收起' : '展开';
+              }
+            }),
+            actionBarStyle: new ActionBarStyle({
+              isPrimaryIconChanged: this.isPrimaryIconChanged
+            }),
+            isExpand: this.isExpand
+          })
+            .bindMenu(this.TokenAddMenu(), { placement: Placement.BottomRight })
         }
-        .height(this.plus_btn_height)
-        .backgroundColor($r('app.color.token_number'))
-        .shadow({ radius: 10, color: $r('app.color.shadow') })
-        .margin({ bottom: 10, right: 10 })
-        .padding(10)
-        .bindMenu(this.TokenAddMenu(), { placement: Placement.BottomRight })
-        .onClick(() => {
-          this.btn_token_add_clicked += 1
-        })
-        .accessibilityText($r('app.string.app_ua_add_token'))
+        .width('100%')
+        .justifyContent(FlexAlign.Center)
+        .margin({ bottom: this.appBottomAvoidHeight + 35 })
       }
     }
   }

--- a/entry/src/main/ets/utils/CryptoUtils.ets
+++ b/entry/src/main/ets/utils/CryptoUtils.ets
@@ -2,7 +2,7 @@ import { BusinessError } from '@kit.BasicServicesKit';
 import { cryptoFramework } from '@kit.CryptoArchitectureKit';
 import { buffer, util } from '@kit.ArkTS';
 import { base32Decode,stringToIntArray,stringToArray } from '../utils/TokenUtils'
-import promptAction from '@ohos.promptAction'
+import { showSnackBar, SnackBarNotifyType } from './HdsSnackBarUtils';
 
 export async function decryptFile(file_buf: Uint8Array, user_key: string): Promise<string> {
   let aes_decoder = cryptoFramework.createCipher('AES128|CBC|PKCS7');
@@ -23,14 +23,14 @@ export async function decryptFile(file_buf: Uint8Array, user_key: string): Promi
   let aes_key = aesGenerator.convertKeySync(symKeyBlob);
   await aes_decoder.init(cryptoFramework.CryptoMode.DECRYPT_MODE, aes_key, aes_iv)
     .catch((reason: string) => {
-      promptAction.showToast({ message: reason });
+      showSnackBar(reason, SnackBarNotifyType.ERROR);
     });
   return new Promise<string>((resolve) => {
     aes_decoder.doFinal({ data: file_buf }).then((decryptData) => {
       let decoder = new util.TextDecoder()
       resolve(decoder.decodeToString(decryptData.data));
     }).catch((reason: BusinessError) => {
-      promptAction.showToast({ message: reason.message });
+      showSnackBar(reason.message, SnackBarNotifyType.ERROR);
     });
   });
 }
@@ -90,7 +90,7 @@ export async function decryptUint8ArrayData(data: Uint8Array, symKeyBlob: crypto
   let aes_key = aesGenerator.convertKeySync(symKeyBlob);
   await aes_decoder.init(cryptoFramework.CryptoMode.DECRYPT_MODE, aes_key, aes_iv)
     .catch((reason: string) => {
-      promptAction.showToast({ message: reason });
+      showSnackBar(reason, SnackBarNotifyType.ERROR);
     });
   return new Promise<Uint8Array|null>((resolve) => {
     aes_decoder.doFinal({ data: data }).then((decryptData) => {

--- a/entry/src/main/ets/utils/HdsSnackBarUtils.ets
+++ b/entry/src/main/ets/utils/HdsSnackBarUtils.ets
@@ -1,4 +1,4 @@
-import { AppStorageV2 } from '@kit.ArkUI';
+import { AppStorageV2, SymbolGlyphModifier } from '@kit.ArkUI';
 import {
   HdsSnackBar,
   SnackBarIconOptions,
@@ -9,6 +9,7 @@ import {
   SnackBarStyleOptions
 } from '@kit.UIDesignKit';
 import { AppWindowInfo } from '../entryability/EntryAbility';
+import { common, ConfigurationConstant } from '@kit.AbilityKit';
 
 export enum SnackBarNotifyType {
   INFO = 'INFO',
@@ -24,11 +25,30 @@ const SnackBarIconMap: Record<SnackBarNotifyType, ResourceStr | undefined> = {
   [SnackBarNotifyType.SUCCESS]: $r('sys.symbol.checkmark_circle')
 };
 
+const SnackBarIconColorMapLight: Record<SnackBarNotifyType, SymbolGlyphModifier> = {
+  [SnackBarNotifyType.INFO]: new SymbolGlyphModifier().fontColor([Color.Blue]),
+  [SnackBarNotifyType.WARNING]: new SymbolGlyphModifier().fontColor([Color.Orange]),
+  [SnackBarNotifyType.ERROR]: new SymbolGlyphModifier().fontColor([Color.Red]),
+  [SnackBarNotifyType.SUCCESS]: new SymbolGlyphModifier().fontColor([Color.Green])
+};
+
+const SnackBarIconColorMapDark: Record<SnackBarNotifyType, SymbolGlyphModifier> = {
+  [SnackBarNotifyType.INFO]: new SymbolGlyphModifier().fontColor([0xFF8FD3FF]),
+  [SnackBarNotifyType.WARNING]: new SymbolGlyphModifier().fontColor([0xFFFFC266]),
+  [SnackBarNotifyType.ERROR]: new SymbolGlyphModifier().fontColor([0xFFFF8A8A]),
+  [SnackBarNotifyType.SUCCESS]: new SymbolGlyphModifier().fontColor([0xFF7EE7A3])
+};
+
 let snackBar: HdsSnackBar | undefined;
 
 function getUiContext(): UIContext | undefined {
   const windowInfo = AppStorageV2.connect(AppWindowInfo) as AppWindowInfo;
-  return windowInfo?.uiContext;
+  return windowInfo.uiContext;
+}
+
+function getUiAbilityContext(): common.UIAbilityContext | undefined {
+  const windowInfo = AppStorageV2.connect(AppWindowInfo) as AppWindowInfo;
+  return windowInfo.Context;
 }
 
 export interface SnackBarNotifyOptions {
@@ -42,6 +62,7 @@ export function showSnackBar(
   options: SnackBarNotifyOptions = {}
 ): void {
   const uiContext = getUiContext();
+  const abilityContext = getUiAbilityContext();
   if (!uiContext) {
     return;
   }
@@ -50,9 +71,11 @@ export function showSnackBar(
     snackBar = new HdsSnackBar(uiContext);
   }
 
+  const useDarkColors = abilityContext?.config?.colorMode === ConfigurationConstant.ColorMode.COLOR_MODE_DARK;
   const iconOptions: SnackBarIconOptions = {
     icon: SnackBarIconMap[type],
-    iconType: SnackBarIconType.SMALL
+    iconType: SnackBarIconType.SMALL,
+    iconSymbolModifier: useDarkColors ? SnackBarIconColorMapDark[type] : SnackBarIconColorMapLight[type],
   };
 
   const messageOptions: SnackBarMessageOptions = {

--- a/entry/src/main/ets/utils/HdsSnackBarUtils.ets
+++ b/entry/src/main/ets/utils/HdsSnackBarUtils.ets
@@ -1,0 +1,75 @@
+import { AppStorageV2 } from '@kit.ArkUI';
+import {
+  HdsSnackBar,
+  SnackBarIconOptions,
+  SnackBarIconType,
+  SnackBarMessageOptions,
+  SnackBarOperationOptions,
+  SnackBarOperationType,
+  SnackBarStyleOptions
+} from '@kit.UIDesignKit';
+import { AppWindowInfo } from '../entryability/EntryAbility';
+
+export enum SnackBarNotifyType {
+  INFO = 'INFO',
+  WARNING = 'WARNING',
+  ERROR = 'ERROR',
+  SUCCESS = 'SUCCESS'
+}
+
+const SnackBarIconMap: Record<SnackBarNotifyType, ResourceStr | undefined> = {
+  [SnackBarNotifyType.INFO]: $r('sys.symbol.info_circle'),
+  [SnackBarNotifyType.WARNING]: $r('sys.symbol.exclamationmark_triangle'),
+  [SnackBarNotifyType.ERROR]: $r('sys.symbol.xmark_circle'),
+  [SnackBarNotifyType.SUCCESS]: $r('sys.symbol.checkmark_circle')
+};
+
+let snackBar: HdsSnackBar | undefined;
+
+function getUiContext(): UIContext | undefined {
+  const windowInfo = AppStorageV2.connect(AppWindowInfo) as AppWindowInfo;
+  return windowInfo?.uiContext;
+}
+
+export interface SnackBarNotifyOptions {
+  title?: ResourceStr;
+  duration?: number;
+}
+
+export function showSnackBar(
+  message: ResourceStr,
+  type: SnackBarNotifyType = SnackBarNotifyType.INFO,
+  options: SnackBarNotifyOptions = {}
+): void {
+  const uiContext = getUiContext();
+  if (!uiContext) {
+    return;
+  }
+
+  if (!snackBar) {
+    snackBar = new HdsSnackBar(uiContext);
+  }
+
+  const iconOptions: SnackBarIconOptions = {
+    icon: SnackBarIconMap[type],
+    iconType: SnackBarIconType.SMALL
+  };
+
+  const messageOptions: SnackBarMessageOptions = {
+    content: message
+  };
+
+  if (options.title) {
+    messageOptions.title = options.title;
+  }
+
+  const operationOptions: SnackBarOperationOptions = {
+    operationType: SnackBarOperationType.CLOSE_BUTTON_ONLY
+  };
+
+  const styleOptions: SnackBarStyleOptions | undefined = options.duration !== undefined
+    ? { duration: options.duration }
+    : undefined;
+
+  snackBar.show(iconOptions, messageOptions, operationOptions, styleOptions);
+}

--- a/entry/src/main/ets/utils/TokenUtils.ets
+++ b/entry/src/main/ets/utils/TokenUtils.ets
@@ -4,11 +4,11 @@ import { common } from '@kit.AbilityKit';
 import { otpType, TokenConfig } from './TokenConfig';
 import { scanBarcode, scanCore } from '@kit.ScanKit';
 import { pasteboard } from '@kit.BasicServicesKit';
-import { promptAction } from '@kit.ArkUI';
 import { fileIo as fs } from '@kit.CoreFileKit';
 import { readFileContent } from './FileUtils';
 import { fileIo } from '@kit.CoreFileKit';
 import { AppPreference } from './AppPreference';
+import { showSnackBar, SnackBarNotifyType } from './HdsSnackBarUtils';
 
 const RFC4648 = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
 const RFC4648_HEX = '0123456789ABCDEFGHIJKLMNOPQRSTUV';
@@ -231,7 +231,7 @@ export function copyText(text: string, msg: string = '') {
   const systemPasteboard = pasteboard.getSystemPasteboard();
   systemPasteboard.setData(pasteboardData);
   if (msg !== undefined && msg !== '') {
-    promptAction.showToast({ message: msg });
+    showSnackBar(msg, SnackBarNotifyType.INFO);
   }
 }
 
@@ -333,7 +333,7 @@ export class TokenIconPacks {
     const icon_path_json = path + "/pack.json";
     if (!fileIo.accessSync(icon_path_json)) {
       // Display invalid icon pack directories
-      // promptAction.showToast({ message: $r('app.string.toast_icon_pack_invalid') });
+      // showSnackBar($r('app.string.toast_icon_pack_invalid'), SnackBarNotifyType.WARNING);
       // return Promise.reject(new Error("invalid aegis icon pack"));
       let pack: AegisIconPack = new AegisIconPack();
       pack.invalid = true;
@@ -342,7 +342,7 @@ export class TokenIconPacks {
       return;
     }
     if (TokenIconPacks.aegis_icon_packs.filter(pack => pack.on_device_path === path).length > 0) {
-      promptAction.showToast({ message: $r('app.string.toast_icon_pack_already_installed') });
+      showSnackBar($r('app.string.toast_icon_pack_already_installed'), SnackBarNotifyType.WARNING);
       return;
     }
     return readFileContent(icon_path_json).then((val) => {

--- a/entry/src/main/resources/base/element/string.json
+++ b/entry/src/main/resources/base/element/string.json
@@ -253,6 +253,10 @@
       "value": "Add Token"
     },
     {
+      "name": "app_ua_search_token",
+      "value": "Search Token"
+    },
+    {
       "name": "drop_file_import_data",
       "value": "Drop File This Import Data"
     },

--- a/entry/src/main/resources/en_US/element/string.json
+++ b/entry/src/main/resources/en_US/element/string.json
@@ -250,7 +250,11 @@
     },
     {
       "name": "app_ua_add_token",
-      "value": "Add Secret"
+      "value": "Add Token"
+    },
+    {
+      "name": "app_ua_search_token",
+      "value": "Search Token"
     },
     {
       "name": "drop_file_import_data",

--- a/entry/src/main/resources/zh_CN/element/string.json
+++ b/entry/src/main/resources/zh_CN/element/string.json
@@ -253,6 +253,10 @@
       "value": "添加密钥"
     },
     {
+      "name": "app_ua_search_token",
+      "value": "搜索密钥"
+    },
+    {
       "name": "drop_file_import_data",
       "value": "拖入文件导入数据"
     },

--- a/entry/src/main/resources/zh_TW/element/string.json
+++ b/entry/src/main/resources/zh_TW/element/string.json
@@ -253,6 +253,10 @@
       "value": "新增密鑰"
     },
     {
+      "name": "app_ua_search_token",
+      "value": "搜索密鑰"
+    },
+    {
       "name": "drop_file_import_data",
       "value": "拖入檔案匯入資料"
     },


### PR DESCRIPTION
#96 

建议创个`dev`分支然后合到`dev`里，这个版本还没完全做好，临时合一版方便 @eveloki 做一些内容。当前已有：

- HdsSnackBar通知替换所有`showToast`
- 顶部标题栏和一个搜索按钮（还没接入搜索功能），实时模糊
- 底部页签栏，实时模糊

添加Token的`TokenAddMenu`遇到一些阻力，因为HdsActionBar的按钮没法`bindMenu`，所以个人考虑用半模态把Forti，Steam这几个做进去。还有其他方案，这部分可以讨论一下。