### PR TITLE
ui: 搜索按钮触发搜索组件；主按钮使能智感握姿移动位置

### DIFF
--- a/entry/src/main/ets/components/SubItemButton.ets
+++ b/entry/src/main/ets/components/SubItemButton.ets
@@ -9,31 +9,37 @@ export struct SubItemButton {
 
   build() {
     Column() {
-      Row() {
+      Row({ space: 10 }) {
         SymbolGlyph(this.symbol)
           .fontSize(20)
           .fontWeight(FontWeight.Medium)
           .fontColor([$r('app.color.str_main')])
-        Blank()
-          .width(10)
-        Text(this.text)
-          .fontSize($r('sys.float.ohos_id_text_size_body1'))
-          .fontColor($r('sys.color.ohos_id_color_text_primary'))
-          .fontWeight(FontWeight.Regular)
-          .textAlign(TextAlign.Start)
-          .width('100%')
+        Column({ space: 4 }) {
+          Text(this.text)
+            .fontSize($r('sys.float.ohos_id_text_size_body1'))
+            .fontColor($r('sys.color.ohos_id_color_text_primary'))
+            .fontWeight(FontWeight.Regular)
+            .textAlign(TextAlign.Start)
+            .maxLines(1)
+            .textOverflow({ overflow: TextOverflow.Ellipsis })
+          if (this.description != '') {
+            Text(this.description)
+              .fontSize($r('sys.float.ohos_id_text_size_body2'))
+              .fontColor(this.descriptionColor)
+              .fontWeight(FontWeight.Regular)
+              .fontFamily('HarmonyHeiTi')
+              .lineHeight(19)
+              .textAlign(TextAlign.Start)
+              .maxLines(2)
+              .textOverflow({ overflow: TextOverflow.Ellipsis })
+          }
+        }
+        .layoutWeight(1)
+        .alignItems(HorizontalAlign.Start)
       }
+      .width('100%')
       .alignItems(VerticalAlign.Center)
       .justifyContent(FlexAlign.Start)
-      if (this.description != '') {
-        Text(this.description)
-          .fontSize($r('sys.float.ohos_id_text_size_body2'))
-          .fontColor(this.descriptionColor)
-          .fontWeight(FontWeight.Regular)
-          .fontFamily('HarmonyHeiTi')
-          .lineHeight(19)
-          .width('100%')
-      }
     }
     .clickEffect({ level: ClickEffectLevel.LIGHT, scale: 0.95 })
     .padding(10)

--- a/entry/src/main/ets/components/SubItemColor.ets
+++ b/entry/src/main/ets/components/SubItemColor.ets
@@ -24,8 +24,8 @@ export struct SubItemColor {
 
   build() {
     Column() {
-      Row() {
-        Column() {
+      Row({ space: 12 }) {
+        Column({ space: 4 }) {
           Row({ space: 10 }) {
             if (this.icon != undefined) {
               SymbolGlyph(this.icon)
@@ -38,9 +38,12 @@ export struct SubItemColor {
               .fontColor($r('sys.color.ohos_id_color_text_primary'))
               .fontWeight(FontWeight.Regular)
               .textAlign(TextAlign.Start)
-              .layoutWeight(2)
+              .maxLines(1)
+              .textOverflow({ overflow: TextOverflow.Ellipsis })
+              .layoutWeight(1)
           }
           .width('100%')
+          .alignItems(VerticalAlign.Center)
           if (this.description != '') {
             Text(this.description)
               .fontSize($r('sys.float.ohos_id_text_size_body2'))
@@ -48,13 +51,14 @@ export struct SubItemColor {
               .fontWeight(FontWeight.Regular)
               .fontFamily('HarmonyHeiTi')
               .lineHeight(19)
-              .width('100%')
+              .textAlign(TextAlign.Start)
+              .maxLines(2)
+              .textOverflow({ overflow: TextOverflow.Ellipsis })
           }
         }
-        .width('80%')
-        Blank()
+        .layoutWeight(1)
+        .alignItems(HorizontalAlign.Start)
         Row({ space: 10 }) {
-          Blank()
           SymbolGlyph($r('sys.symbol.chevron_right'))
             .fontColor([$r('sys.color.font_tertiary')])
             .fontSize(24)
@@ -62,7 +66,7 @@ export struct SubItemColor {
             .rotate(this.collapsed ? { angle: 0 } : { angle: 90 })
             .translate(this.collapsed ? {} : { x: -3 })
         }
-        .layoutWeight(1)
+        .alignItems(VerticalAlign.Center)
         .onClick(() => {
           this.window.uiContext?.animateTo({ duration: 200, curve: Curve.Sharp }, () => {
             this.collapsed = !this.collapsed;
@@ -70,7 +74,8 @@ export struct SubItemColor {
         })
 
       }
-      .justifyContent(FlexAlign.SpaceAround)
+      .width('100%')
+      .alignItems(VerticalAlign.Center)
       if (!this.collapsed) {
         Blank()
           .height(10)

--- a/entry/src/main/ets/components/SubItemDecoration.ets
+++ b/entry/src/main/ets/components/SubItemDecoration.ets
@@ -14,8 +14,8 @@ export struct SubItemDecoration {
 
   build() {
     Column() {
-      Row() {
-        Column() {
+      Row({ space: 12 }) {
+        Column({ space: 4 }) {
           Row({ space: 10 }) {
             if (this.icon != undefined) {
               SymbolGlyph(this.icon)
@@ -28,9 +28,12 @@ export struct SubItemDecoration {
               .fontColor($r('sys.color.ohos_id_color_text_primary'))
               .fontWeight(FontWeight.Regular)
               .textAlign(TextAlign.Start)
-              .layoutWeight(2)
+              .maxLines(1)
+              .textOverflow({ overflow: TextOverflow.Ellipsis })
+              .layoutWeight(1)
           }
           .width('100%')
+          .alignItems(VerticalAlign.Center)
           if (this.description != '') {
             Text(this.description)
               .fontSize($r('sys.float.ohos_id_text_size_body2'))
@@ -38,13 +41,14 @@ export struct SubItemDecoration {
               .fontWeight(FontWeight.Regular)
               .fontFamily('HarmonyHeiTi')
               .lineHeight(19)
-              .width('100%')
+              .textAlign(TextAlign.Start)
+              .maxLines(2)
+              .textOverflow({ overflow: TextOverflow.Ellipsis })
           }
         }
-        .width('80%')
-        Blank()
+        .layoutWeight(1)
+        .alignItems(HorizontalAlign.Start)
         Row({ space: 10 }) {
-          Blank()
           SymbolGlyph($r('sys.symbol.chevron_right'))
             .fontColor([$r('sys.color.font_tertiary')])
             .fontSize(24)
@@ -52,7 +56,7 @@ export struct SubItemDecoration {
             .rotate(this.collapsed ? { angle: 0 } : { angle: 90 })
             .translate(this.collapsed ? {} : { x: -3 })
         }
-        .layoutWeight(1)
+        .alignItems(VerticalAlign.Center)
         .onClick(() => {
           this.window.uiContext?.animateTo({ duration: 200, curve: Curve.Sharp }, () => {
             this.collapsed = !this.collapsed;
@@ -60,7 +64,8 @@ export struct SubItemDecoration {
         })
 
       }
-      .justifyContent(FlexAlign.SpaceAround)
+      .width('100%')
+      .alignItems(VerticalAlign.Center)
       if (!this.collapsed) {
         Blank()
           .height(10)

--- a/entry/src/main/ets/components/SubItemSelect.ets
+++ b/entry/src/main/ets/components/SubItemSelect.ets
@@ -12,20 +12,40 @@ export struct SubItemSelect {
 
   build() {
     Column() {
-      Row({ space: 10 }) {
-        if (this.icon != undefined) {
-          SymbolGlyph(this.icon)
-            .fontSize(20)
-            .fontWeight(FontWeight.Medium)
-            .fontColor([$r('app.color.str_main')])
+      Row({ space: 12 }) {
+        Column({ space: 4 }) {
+          Row({ space: 10 }) {
+            if (this.icon != undefined) {
+              SymbolGlyph(this.icon)
+                .fontSize(20)
+                .fontWeight(FontWeight.Medium)
+                .fontColor([$r('app.color.str_main')])
+            }
+            Text(this.title)
+              .fontSize($r('sys.float.ohos_id_text_size_body1'))
+              .fontColor($r('sys.color.ohos_id_color_text_primary'))
+              .fontWeight(FontWeight.Regular)
+              .textAlign(TextAlign.Start)
+              .maxLines(1)
+              .textOverflow({ overflow: TextOverflow.Ellipsis })
+              .layoutWeight(1)
+          }
+          .width('100%')
+          .alignItems(VerticalAlign.Center)
+          if (this.description != '') {
+            Text(this.description)
+              .fontSize($r('sys.float.ohos_id_text_size_body2'))
+              .fontColor($r('sys.color.ohos_id_color_text_secondary'))
+              .fontWeight(FontWeight.Regular)
+              .fontFamily('HarmonyHeiTi')
+              .lineHeight(19)
+              .textAlign(TextAlign.Start)
+              .maxLines(2)
+              .textOverflow({ overflow: TextOverflow.Ellipsis })
+          }
         }
-        Text(this.title)
-          .fontSize($r('sys.float.ohos_id_text_size_body1'))
-          .fontColor($r('sys.color.ohos_id_color_text_primary'))
-          .fontWeight(FontWeight.Regular)
-          .textAlign(TextAlign.Start)
-
-        Blank()
+        .layoutWeight(1)
+        .alignItems(HorizontalAlign.Start)
 
         Select(this.values.map((val: string | Resource) => {return { value: val as string } as SelectOption }))
           .enabled(!this.disable)
@@ -36,15 +56,7 @@ export struct SubItemSelect {
           })
       }
       .width('100%')
-      if (this.description != '') {
-        Text(this.description)
-          .fontSize($r('sys.float.ohos_id_text_size_body2'))
-          .fontColor($r('sys.color.ohos_id_color_text_secondary'))
-          .fontWeight(FontWeight.Regular)
-          .fontFamily('HarmonyHeiTi')
-          .lineHeight(19)
-          .width('100%')
-      }
+      .alignItems(VerticalAlign.Center)
     }
     .padding(10)
   }

--- a/entry/src/main/ets/components/SubItemSlider.ets
+++ b/entry/src/main/ets/components/SubItemSlider.ets
@@ -29,8 +29,8 @@ export struct SubItemSlider {
 
   build() {
     Column() {
-      Row() {
-        Column() {
+      Row({ space: 12 }) {
+        Column({ space: 4 }) {
           Row({ space: 10 }) {
             if (this.icon != undefined) {
               SymbolGlyph(this.icon)
@@ -43,11 +43,12 @@ export struct SubItemSlider {
               .fontColor($r('sys.color.ohos_id_color_text_primary'))
               .fontWeight(FontWeight.Regular)
               .textAlign(TextAlign.Start)
-              .layoutWeight(2)
-
-
+              .maxLines(1)
+              .textOverflow({ overflow: TextOverflow.Ellipsis })
+              .layoutWeight(1)
           }
           .width('100%')
+          .alignItems(VerticalAlign.Center)
           if (this.description != '') {
             Text(this.description)
               .fontSize($r('sys.float.ohos_id_text_size_body2'))
@@ -55,13 +56,14 @@ export struct SubItemSlider {
               .fontWeight(FontWeight.Regular)
               .fontFamily('HarmonyHeiTi')
               .lineHeight(19)
-              .width('100%')
+              .textAlign(TextAlign.Start)
+              .maxLines(2)
+              .textOverflow({ overflow: TextOverflow.Ellipsis })
           }
         }
-        .width('80%')
-        Blank()
+        .layoutWeight(1)
+        .alignItems(HorizontalAlign.Start)
         Row({ space: 10 }) {
-          Blank()
           SymbolGlyph($r('sys.symbol.chevron_right'))
             .fontColor([$r('sys.color.font_tertiary')])
             .fontSize(24)
@@ -69,14 +71,15 @@ export struct SubItemSlider {
             .rotate(this.collapsed ? { angle: 0 } : { angle: 90 })
             .translate(this.collapsed ? {} : { x: -3 })
         }
-        .layoutWeight(1)
+        .alignItems(VerticalAlign.Center)
         .onClick(() => {
           this.window.uiContext?.animateTo({ duration: 200, curve: Curve.Sharp }, () => {
             this.collapsed = !this.collapsed;
           })
         })
       }
-      .justifyContent(FlexAlign.SpaceAround)
+      .width('100%')
+      .alignItems(VerticalAlign.Center)
 
       if (!this.collapsed) {
         Blank()

--- a/entry/src/main/ets/components/SubItemToggle.ets
+++ b/entry/src/main/ets/components/SubItemToggle.ets
@@ -12,21 +12,40 @@ export struct SubItemToggle {
 
   build() {
     Column() {
-      Row({ space: 10 }) {
-        if (this.icon != undefined) {
-          SymbolGlyph(this.icon)
-            .fontSize(20)
-            .fontWeight(FontWeight.Medium)
-            .fontColor([$r('app.color.str_main')])
+      Row({ space: 12 }) {
+        Column({ space: 4 }) {
+          Row({ space: 10 }) {
+            if (this.icon != undefined) {
+              SymbolGlyph(this.icon)
+                .fontSize(20)
+                .fontWeight(FontWeight.Medium)
+                .fontColor([$r('app.color.str_main')])
+            }
+            Text(this.title)
+              .fontSize($r('sys.float.ohos_id_text_size_body1'))
+              .fontColor($r('sys.color.ohos_id_color_text_primary'))
+              .fontWeight(FontWeight.Regular)
+              .textAlign(TextAlign.Start)
+              .maxLines(1)
+              .textOverflow({ overflow: TextOverflow.Ellipsis })
+              .layoutWeight(1)
+          }
+          .width('100%')
+          .alignItems(VerticalAlign.Center)
+          if (this.description != '') {
+            Text(this.description)
+              .fontSize($r('sys.float.ohos_id_text_size_body2'))
+              .fontColor(this.descriptionColor)
+              .fontWeight(FontWeight.Regular)
+              .fontFamily('HarmonyHeiTi')
+              .lineHeight(19)
+              .textAlign(TextAlign.Start)
+              .maxLines(2)
+              .textOverflow({ overflow: TextOverflow.Ellipsis })
+          }
         }
-        Text(this.title)
-          .fontSize($r('sys.float.ohos_id_text_size_body1'))
-          .fontColor($r('sys.color.ohos_id_color_text_primary'))
-          .fontWeight(FontWeight.Regular)
-          .textAlign(TextAlign.Start)
-          .layoutWeight(2)
-
-        Blank()
+        .layoutWeight(1)
+        .alignItems(HorizontalAlign.Start)
 
         Toggle({ type: ToggleType.Switch, isOn: this.isOn })
           .id('ToggleSwitch')
@@ -39,15 +58,7 @@ export struct SubItemToggle {
           .clickEffect({ level: ClickEffectLevel.LIGHT, scale: 0.95 })
       }
       .width('100%')
-      if (this.description != '') {
-        Text(this.description)
-          .fontSize($r('sys.float.ohos_id_text_size_body2'))
-          .fontColor(this.descriptionColor)
-          .fontWeight(FontWeight.Regular)
-          .fontFamily('HarmonyHeiTi')
-          .lineHeight(19)
-          .width('100%')
-      }
+      .alignItems(VerticalAlign.Center)
     }
     .padding(10)
   }

--- a/entry/src/main/ets/pages/Index.ets
+++ b/entry/src/main/ets/pages/Index.ets
@@ -709,7 +709,7 @@ struct Index {
                   icon: $r('sys.symbol.magnifyingglass'),
                   isEnabled: true,
                   action: () => {
-                    //TODO: 下拉搜索触发改成这里触发
+                    if (this.appCtx.eventHub != undefined) this.appCtx.eventHub.emit('toggleTokenSearch');
                   }
                 }
               }
@@ -760,7 +760,7 @@ struct Index {
                   icon: $r('sys.symbol.magnifyingglass'),
                   isEnabled: true,
                   action: () => {
-                    //TODO: 下拉搜索触发改成这里触发
+                    if (this.appCtx.eventHub != undefined) this.appCtx.eventHub.emit('toggleTokenSearch');
                   }
                 }
               }
@@ -808,7 +808,7 @@ struct Index {
                         icon: $r('sys.symbol.magnifyingglass'),
                         isEnabled: true,
                         action: () => {
-                          //TODO: 下拉搜索触发改成这里触发
+                          if (this.appCtx.eventHub != undefined) this.appCtx.eventHub.emit('toggleTokenSearch');
                         }
                       }
                     }

--- a/entry/src/main/ets/pages/TokenListPage.ets
+++ b/entry/src/main/ets/pages/TokenListPage.ets
@@ -86,7 +86,10 @@ export struct TokenListPage {
     }
     getContext(this).eventHub.on('startQuickScan', () => { this.start_quick_scan() });
     getContext(this).eventHub.on('toggleTokenSearch', () => { this.toggleTokenSearchByTitleBar() });
-    this.initHoldingHandAwareness();
+    getContext(this).eventHub.on('holdingHandPreferenceChanged', (enabled: boolean) => {
+      this.handleHoldingHandPreferenceChanged(enabled);
+    });
+    this.handleHoldingHandPreferenceChanged(this.token_preference.app_appearance_holding_hand_enable);
   }
 
   aboutToDisappear(): void {
@@ -123,6 +126,15 @@ export struct TokenListPage {
       return;
     }
     this.subscribeHoldingHandAwareness();
+  }
+
+  private handleHoldingHandPreferenceChanged(enabled: boolean): void {
+    if (!enabled) {
+      this.unsubscribeHoldingHandAwareness();
+      this.applyHoldingHandLayout(HoldingHandLayoutMode.CENTER);
+      return;
+    }
+    this.initHoldingHandAwareness();
   }
 
   private async ensureHoldingHandPermission(): Promise<boolean> {

--- a/entry/src/main/ets/pages/TokenListPage.ets
+++ b/entry/src/main/ets/pages/TokenListPage.ets
@@ -34,11 +34,8 @@ export struct TokenListPage {
   @Local token_copy_guide_popup: boolean = false;
 
   @Local token_list_search_result: TokenConfig[] = [];
-  @Local token_list_search_start: boolean = false;
   @Local token_list_search_visible: boolean = false;
   @Local token_list_search_enable: boolean = false;
-  @Local token_list_touch_down_pos: number = 0;
-  @Local token_list_touch_move_pos: number = 0;
   @Local token_list_search_str: string = '';
   @Local id_list: string[] = ['search_bar'];
 
@@ -71,6 +68,21 @@ export struct TokenListPage {
       this.token_copy_guide_popup = true;
     }
     getContext(this).eventHub.on('startQuickScan', () => { this.start_quick_scan() });
+    getContext(this).eventHub.on('toggleTokenSearch', () => { this.toggleTokenSearchByTitleBar() });
+  }
+
+  private toggleTokenSearchByTitleBar(): void {
+    this.window.uiContext?.animateTo({ duration: 250, curve: curves.springMotion() }, () => {
+      this.token_list_search_visible = !this.token_list_search_visible;
+      if (!this.token_list_search_visible && this.token_list_search_str.length === 0) {
+        this.token_list_search_enable = false;
+      }
+    })
+    if (!this.token_list_search_visible) {
+      setTimeout(() => {
+        focusControl.requestFocus(this.id_list[0])
+      }, 180)
+    }
   }
 
   build() {
@@ -183,19 +195,6 @@ export struct TokenListPage {
                 },
               }
             })
-            .onTouch((event?: TouchEvent) => {
-              let isMoving = false;
-              if (event?.type === TouchType.Down) {
-                setTimeout(() => {
-                  if (!isMoving) this.token_list_search_start = false;
-                }, 200)
-              }
-              if (event?.type === TouchType.Move) {
-                isMoving = true;
-              } else {
-                this.token_list_search_start = true;
-              }
-            })
           }, (item: TokenConfig) => {
             return JSON.stringify(item)
           })
@@ -221,27 +220,6 @@ export struct TokenListPage {
         .chainAnimation(true)
         .scrollBar(BarState.Off)
         .edgeEffect(EdgeEffect.Spring, { alwaysEnabled: true })
-        .onTouch((event?: TouchEvent) => {
-          this.window.uiContext?.animateTo({ curve: curves.springMotion() }, () => {
-            if (event?.type === TouchType.Down) {
-              this.token_list_touch_down_pos = event.touches[0].y;
-            }
-            if (event?.type === TouchType.Move) {
-              this.token_list_touch_move_pos = event.touches[0].y - this.token_list_touch_down_pos;
-              if (this.token_list_search_start) {
-                if (this.token_list_touch_move_pos > 200) {
-                  this.token_list_search_visible = true;
-                  focusControl.requestFocus(this.id_list[0])
-                } else if (this.token_list_touch_move_pos < -50) {
-                  this.token_list_search_visible = false;
-                }
-              } else {
-                this.token_list_search_visible = false;
-              }
-            }
-          })
-
-        })
       }
       if (this.TabBarVisible) {
         Row() {

--- a/entry/src/main/ets/pages/TokenListPage.ets
+++ b/entry/src/main/ets/pages/TokenListPage.ets
@@ -10,11 +10,20 @@ import { convertToken2URI, ScanBarCode } from "../utils/TokenUtils";
 import { AppStorageV2, ComponentContent, curves, window } from "@kit.ArkUI";
 import { ActionBarButton, ActionBarStyle, HdsActionBar } from "@kit.UIDesignKit";
 import { url } from "@kit.ArkTS";
+import { abilityAccessCtrl, bundleManager, common, Permissions } from "@kit.AbilityKit";
+import { BusinessError } from "@kit.BasicServicesKit";
+import { motion } from "@kit.MultimodalAwarenessKit";
 import { decodeProtobuf } from "../utils/GoogleAuthUtils";
 import { URIConfigDialog } from "../dialogs/URIConfigDialog";
 import { AppWindowInfo } from "../entryability/EntryAbility";
 
 let tkStore = TokenStore.getInstance();
+
+enum HoldingHandLayoutMode {
+  LEFT = 'left',
+  CENTER = 'center',
+  RIGHT = 'right'
+}
 
 @Preview
 @ComponentV2
@@ -30,6 +39,7 @@ export struct TokenListPage {
 
   @Local token_preference: TokenPreference = AppStorageV2.connect(TokenPreference) as TokenPreference;
   @Local window: AppWindowInfo = AppStorageV2.connect(AppWindowInfo) as AppWindowInfo;
+  @Local appCtx: common.UIAbilityContext = AppStorage.get('appContext') as common.UIAbilityContext;
 
   @Local token_copy_guide_popup: boolean = false;
 
@@ -43,12 +53,19 @@ export struct TokenListPage {
   @Local isPrimaryIconChanged: boolean = false;
   @Local primaryHoverTips: string = '收起';
   @Local isTokenAddMenuShown: boolean = false;
+  @Local actionBarOffsetX: number = 0;
+  @Local holdingHandLayoutMode: HoldingHandLayoutMode = HoldingHandLayoutMode.CENTER;
 
   private dialog_uri_config?: CustomDialogController;
   private dialog_totp_config?: CustomDialogController;
   private dialog_forti_config?: CustomDialogController;
   private dialog_steam_config?: CustomDialogController;
   private dialog_qrcode?: CustomDialogController;
+  private readonly holdingHandPermission: Permissions = 'ohos.permission.DETECT_GESTURE';
+  private readonly actionBarMoveRatio: number = 0.22;
+  private readonly actionBarMoveMaxOffset: number = 120;
+  private holdingHandSubscribed: boolean = false;
+  private holdingHandCallback?: Callback<motion.HoldingHandStatus>;
 
   async filterCurrentTokens(filter_word: string): Promise<void> {
     if (filter_word.length === 0) {
@@ -69,6 +86,11 @@ export struct TokenListPage {
     }
     getContext(this).eventHub.on('startQuickScan', () => { this.start_quick_scan() });
     getContext(this).eventHub.on('toggleTokenSearch', () => { this.toggleTokenSearchByTitleBar() });
+    this.initHoldingHandAwareness();
+  }
+
+  aboutToDisappear(): void {
+    this.unsubscribeHoldingHandAwareness();
   }
 
   private toggleTokenSearchByTitleBar(): void {
@@ -88,6 +110,122 @@ export struct TokenListPage {
       setTimeout(() => {
         focusControl.requestFocus(this.id_list[1])
       }, 100)
+    }
+  }
+
+  private async initHoldingHandAwareness(): Promise<void> {
+    this.holdingHandCallback = (status: motion.HoldingHandStatus) => {
+      this.applyHoldingHandLayout(this.mapHoldingHandStatusToLayout(status));
+    };
+    const hasPermission = await this.ensureHoldingHandPermission();
+    if (!hasPermission) {
+      this.applyHoldingHandLayout(HoldingHandLayoutMode.CENTER);
+      return;
+    }
+    this.subscribeHoldingHandAwareness();
+  }
+
+  private async ensureHoldingHandPermission(): Promise<boolean> {
+    const granted = await this.checkPermissionGranted(this.holdingHandPermission);
+    if (granted) {
+      return true;
+    }
+    if (!this.appCtx) {
+      return false;
+    }
+    try {
+      const requestResult = await abilityAccessCtrl.createAtManager()
+        .requestPermissionsFromUser(this.appCtx, [this.holdingHandPermission]);
+      return requestResult.authResults.every((status) => status === 0);
+    } catch (error) {
+      const err = error as BusinessError;
+      console.error(`Failed to request holding hand permission. Code: ${err.code}, message: ${err.message}`);
+      return false;
+    }
+  }
+
+  private async checkPermissionGranted(permission: Permissions): Promise<boolean> {
+    try {
+      const bundleInfo = await bundleManager.getBundleInfoForSelf(bundleManager.BundleFlag.GET_BUNDLE_INFO_WITH_APPLICATION);
+      const grantStatus = await abilityAccessCtrl.createAtManager().checkAccessToken(bundleInfo.appInfo.accessTokenId, permission);
+      return grantStatus === abilityAccessCtrl.GrantStatus.PERMISSION_GRANTED;
+    } catch (error) {
+      const err = error as BusinessError;
+      console.error(`Failed to check holding hand permission. Code: ${err.code}, message: ${err.message}`);
+      return false;
+    }
+  }
+
+  private subscribeHoldingHandAwareness(): void {
+    if (this.holdingHandSubscribed || !this.holdingHandCallback) {
+      return;
+    }
+    try {
+      motion.on('holdingHandChanged', this.holdingHandCallback);
+      this.holdingHandSubscribed = true;
+    } catch (error) {
+      const err = error as BusinessError;
+      if (err.code === 801 || err.code === 201) {
+        this.applyHoldingHandLayout(HoldingHandLayoutMode.CENTER);
+      }
+      console.error(`Failed to subscribe holding hand awareness. Code: ${err.code}, message: ${err.message}`);
+    }
+  }
+
+  private unsubscribeHoldingHandAwareness(): void {
+    if (!this.holdingHandSubscribed) {
+      return;
+    }
+    try {
+      if (this.holdingHandCallback) {
+        motion.off('holdingHandChanged', this.holdingHandCallback);
+      } else {
+        motion.off('holdingHandChanged');
+      }
+    } catch (error) {
+      const err = error as BusinessError;
+      console.error(`Failed to unsubscribe holding hand awareness. Code: ${err.code}, message: ${err.message}`);
+    } finally {
+      this.holdingHandSubscribed = false;
+    }
+  }
+
+  private mapHoldingHandStatusToLayout(status: motion.HoldingHandStatus): HoldingHandLayoutMode {
+    switch (status) {
+      case motion.HoldingHandStatus.LEFT_HAND_HELD:
+        return HoldingHandLayoutMode.LEFT;
+      case motion.HoldingHandStatus.RIGHT_HAND_HELD:
+        return HoldingHandLayoutMode.RIGHT;
+      case motion.HoldingHandStatus.BOTH_HANDS_HELD:
+      case motion.HoldingHandStatus.NOT_HELD:
+      case motion.HoldingHandStatus.UNKNOWN_STATUS:
+      default:
+        return HoldingHandLayoutMode.CENTER;
+    }
+  }
+
+  private applyHoldingHandLayout(mode: HoldingHandLayoutMode): void {
+    const nextOffset = this.getActionBarOffsetByMode(mode);
+    if (this.holdingHandLayoutMode === mode && this.actionBarOffsetX === nextOffset) {
+      return;
+    }
+    this.window.uiContext?.animateTo({ duration: 300, curve: curves.springMotion() }, () => {
+      this.holdingHandLayoutMode = mode;
+      this.actionBarOffsetX = nextOffset;
+    })
+  }
+
+  private getActionBarOffsetByMode(mode: HoldingHandLayoutMode): number {
+    const width = Number(this.appWindowSize.width ?? 0);
+    const baseOffset = Math.min(width * this.actionBarMoveRatio, this.actionBarMoveMaxOffset);
+    switch (mode) {
+      case HoldingHandLayoutMode.LEFT:
+        return -baseOffset;
+      case HoldingHandLayoutMode.RIGHT:
+        return baseOffset;
+      case HoldingHandLayoutMode.CENTER:
+      default:
+        return 0;
     }
   }
 
@@ -270,6 +408,7 @@ export struct TokenListPage {
             }),
             isExpand: this.isExpand
           })
+            .translate({ x: this.actionBarOffsetX, y: 0 })
             .bindMenu(this.isTokenAddMenuShown, this.TokenAddMenu, {
               placement: Placement.BottomLeft,
               onWillDisappear: () => {

--- a/entry/src/main/ets/pages/TokenListPage.ets
+++ b/entry/src/main/ets/pages/TokenListPage.ets
@@ -37,7 +37,7 @@ export struct TokenListPage {
   @Local token_list_search_visible: boolean = false;
   @Local token_list_search_enable: boolean = false;
   @Local token_list_search_str: string = '';
-  @Local id_list: string[] = ['search_bar'];
+  @Local id_list: string[] = ['search_bar', 'search_blur_anchor'];
 
   @Local isExpand: boolean = false;
   @Local isPrimaryIconChanged: boolean = false;
@@ -72,21 +72,34 @@ export struct TokenListPage {
   }
 
   private toggleTokenSearchByTitleBar(): void {
+    const nextVisible = !this.token_list_search_visible;
     this.window.uiContext?.animateTo({ duration: 250, curve: curves.springMotion() }, () => {
-      this.token_list_search_visible = !this.token_list_search_visible;
-      if (!this.token_list_search_visible && this.token_list_search_str.length === 0) {
+      this.token_list_search_visible = nextVisible;
+      if (!this.token_list_search_visible) {
+        this.token_list_search_str = '';
         this.token_list_search_enable = false;
       }
     })
-    if (!this.token_list_search_visible) {
+    if (nextVisible) {
       setTimeout(() => {
         focusControl.requestFocus(this.id_list[0])
       }, 180)
+    } else {
+      setTimeout(() => {
+        focusControl.requestFocus(this.id_list[1])
+      }, 100)
     }
   }
 
   build() {
     Stack({ alignContent: Alignment.Bottom }) {
+      Button('')
+        .id(this.id_list[1])
+        .focusable(true)
+        .width(1)
+        .height(1)
+        .opacity(0)
+        .position({ x: 0, y: 0 })
       if (this.Tokens.length === 0) {
         Row() {
           Text(this.token_list_search_enable ? $r('app.string.app_token_list_search_msg') :
@@ -127,23 +140,24 @@ export struct TokenListPage {
                     .onSubmit(() => {
                       this.filterCurrentTokens(this.token_list_search_str);
                     })
-                  SymbolGlyph(this.token_list_search_enable ? $r('sys.symbol.xmark') :
-                  $r('sys.symbol.magnifyingglass'))
+                  SymbolGlyph($r('sys.symbol.xmark'))
                     .fontSize(20)
                     .fontWeight(FontWeight.Medium)
                     .fontColor([$r('app.color.item_fg')])
                     .padding({ right: 10 })
                     .onClick(() => {
-                      if (this.token_list_search_enable) {
-                        this.token_list_search_str = '';
-                      }
-                      this.filterCurrentTokens(this.token_list_search_str);
+                      this.toggleTokenSearchByTitleBar();
                     })
                 }
-                .padding({ left: 10, right: 10, top: 10 })
+                .padding({ left: 10, right: 10, top: this.token_list_search_visible || this.token_list_search_enable ? 10 : 0 })
                 .width('100%')
-                .visibility(this.token_list_search_visible || this.token_list_search_enable ?
-                Visibility.Visible : Visibility.None)
+                .height(this.token_list_search_visible || this.token_list_search_enable ? 56 : 0)
+                .opacity(this.token_list_search_visible || this.token_list_search_enable ? 1 : 0)
+                .translate({
+                  x: 0,
+                  y: this.token_list_search_visible || this.token_list_search_enable ? 0 : -12
+                })
+                .clip(true)
               }
             }
           }

--- a/entry/src/main/ets/pages/setting/AppearanceSheet.ets
+++ b/entry/src/main/ets/pages/setting/AppearanceSheet.ets
@@ -37,6 +37,20 @@ export struct AppearanceSheet {
 
           SubItemDivider()
 
+          SubItemToggle({
+            icon: $r('sys.symbol.phone_and_hand'),
+            title: $r('app.string.setting_holding_hand_awareness'),
+            isOn: AppPreference.getPreference('app_appearance_holding_hand_enable') as boolean,
+            description: $r('app.string.setting_holding_hand_awareness_des'),
+            onChange: (IsOn: boolean) => {
+              AppPreference.setPreference('app_appearance_holding_hand_enable', IsOn);
+              this.token_preference.app_appearance_holding_hand_enable = IsOn;
+              this.appCtx.eventHub.emit('holdingHandPreferenceChanged', IsOn);
+            }
+          })
+
+          SubItemDivider()
+
           if (this.debug_mode_is_on) {
             SubItemToggle({
               icon: $r('sys.symbol.gearshape'),

--- a/entry/src/main/ets/pages/setting/SettingPage.ets
+++ b/entry/src/main/ets/pages/setting/SettingPage.ets
@@ -427,6 +427,20 @@ export struct SettingPage {
 
               SubItemDivider()
 
+              SubItemToggle({
+                icon: $r('sys.symbol.hand_draw'),
+                title: $r('app.string.setting_holding_hand_awareness'),
+                isOn: AppPreference.getPreference('app_appearance_holding_hand_enable') as boolean,
+                description: $r('app.string.setting_holding_hand_awareness_des'),
+                onChange: (IsOn: boolean) => {
+                  AppPreference.setPreference('app_appearance_holding_hand_enable', IsOn);
+                  this.token_preference.app_appearance_holding_hand_enable = IsOn;
+                  this.appCtx.eventHub.emit('holdingHandPreferenceChanged', IsOn);
+                }
+              })
+
+              SubItemDivider()
+
               if (this.debug_mode_is_on) {
                 SubItemToggle({
                   icon: $r('sys.symbol.gearshape'),

--- a/entry/src/main/ets/utils/AppPreference.ets
+++ b/entry/src/main/ets/utils/AppPreference.ets
@@ -12,6 +12,7 @@ export enum SettingColorMode {
 export class TokenPreference {
   @Trace app_safety_hide_token_enable = false;
   @Trace app_appearance_show_next_token_enable = false;
+  @Trace app_appearance_holding_hand_enable = false;
   @Trace app_appearance_swap_host_user_enable = false;
   @Trace app_appearance_item_height = 60;
   @Trace app_appearance_item_space = 10;
@@ -61,6 +62,8 @@ export class AppPreference {
     ['app_safety_background_blur_enable', false],
     // 外观-显示下一个令牌
     ['app_appearance_show_next_token_enable', false],
+    // 外观-智感握姿
+    ['app_appearance_holding_hand_enable', false],
     // 外观-颜色模式
     ['app_appearance_color_mode', SettingColorMode.System],
     // 外观-图标包
@@ -150,6 +153,7 @@ export class AppPreference {
     let token_appearance: TokenPreference = AppStorageV2.connect(TokenPreference, () => new TokenPreference())!;
     token_appearance.app_safety_hide_token_enable = AppPreference.getPreference('app_safety_hide_token_enable') as boolean;
     token_appearance.app_appearance_show_next_token_enable = AppPreference.getPreference('app_appearance_show_next_token_enable') as boolean;
+    token_appearance.app_appearance_holding_hand_enable = AppPreference.getPreference('app_appearance_holding_hand_enable') as boolean;
     token_appearance.app_appearance_swap_host_user_enable = AppPreference.getPreference('app_appearance_swap_host_user_enable') as boolean;
     token_appearance.app_appearance_logo_background = AppPreference.getPreference('app_appearance_logo_background') as boolean;
     token_appearance.app_appearance_item_height = AppPreference.getPreference('app_appearance_item_height') as number;

--- a/entry/src/main/module.json5
+++ b/entry/src/main/module.json5
@@ -29,6 +29,9 @@
         "name": "ohos.permission.INTERNET",
       },
       {
+        "name": "ohos.permission.DETECT_GESTURE",
+      },
+      {
         "name": "ohos.permission.VIBRATE",
       },
       {

--- a/entry/src/main/resources/base/element/string.json
+++ b/entry/src/main/resources/base/element/string.json
@@ -313,6 +313,14 @@
       "value": "Display the next token below the current token to enhance usability."
     },
     {
+      "name": "setting_holding_hand_awareness",
+      "value": "Adaptive Grip Sense"
+    },
+    {
+      "name": "setting_holding_hand_awareness_des",
+      "value": "Moves the action bar left, center, or right based on left-hand, both-hand, or right-hand grip. Disabled by default."
+    },
+    {
       "name": "swap_host_user",
       "value": "Swap Displayed Hostname & Username"
     },

--- a/entry/src/main/resources/en_US/element/string.json
+++ b/entry/src/main/resources/en_US/element/string.json
@@ -313,6 +313,14 @@
       "value": "Display the next token below the current one for easier use."
     },
     {
+      "name": "setting_holding_hand_awareness",
+      "value": "Enable Adaptive Grip Sense"
+    },
+    {
+      "name": "setting_holding_hand_awareness_des",
+      "value": "Automatically move the action bar to the left, center, or right for left-hand, both-hand, or right-hand grip. Off by default."
+    },
+    {
       "name": "swap_host_user",
       "value": "Swap Issuer & Username"
     },

--- a/entry/src/main/resources/zh_CN/element/string.json
+++ b/entry/src/main/resources/zh_CN/element/string.json
@@ -313,6 +313,14 @@
       "value": "在当前令牌下方展示下一个令牌，提高易用性。"
     },
     {
+      "name": "setting_holding_hand_awareness",
+      "value": "启用智感握姿"
+    },
+    {
+      "name": "setting_holding_hand_awareness_des",
+      "value": "根据左手、双手或右手握持状态，自动将操作栏移动到左侧、中间或右侧。默认关闭。"
+    },
+    {
       "name": "swap_host_user",
       "value": "交换主机名与用户名"
     },

--- a/entry/src/main/resources/zh_TW/element/string.json
+++ b/entry/src/main/resources/zh_TW/element/string.json
@@ -313,6 +313,14 @@
       "value": "在目前令牌下方展示下一個令牌，提高易用性。"
     },
     {
+      "name": "setting_holding_hand_awareness",
+      "value": "啟用智感握姿"
+    },
+    {
+      "name": "setting_holding_hand_awareness_des",
+      "value": "根據左手、雙手或右手握持狀態，自動將操作欄移動到左側、中間或右側。預設關閉。"
+    },
+    {
       "name": "swap_host_user",
       "value": "交換主機名稱與使用者名稱"
     },


### PR DESCRIPTION
#96 

- 点搜索按钮显示搜索组件
- 智感握姿适配，默认关闭。左右握持时有按钮会到屏幕外面，后续调整位置或者做成半模态
- 设置页每个选项右侧的开关或者下拉等操作组件居中，不受描述文字影响

https://github.com/user-attachments/assets/5b1f97e4-f409-4c3f-a75d-83774a7e4da4

