### PR TITLE
完善外观设置中的顶部模糊类型和底部Tabs类型选项以及修复我的界面顶部遮罩问题

### DIFF
--- a/entry/src/main/ets/pages/Index.ets
+++ b/entry/src/main/ets/pages/Index.ets
@@ -456,33 +456,12 @@ struct Index {
   @Builder
   SettingEntryCardBuilder() {
     List({ space: 10, scroller: this.settingEntryScroller }) {
-
-      // 原有的设置入口（保留以兼容其他设置）
-      //ListItem() {
-      //  HdsListItemCard({
-      //    cardHeight: this.token_preference.app_appearance_item_height,
-      //    prefixItem: new PrefixIcon({
-      //      iconSize: IconSize.SYSTEM_ICON,
-      //      iconValue: {
-      //        symbol: $r('sys.symbol.gearshape')
-      //      }
-      //    }),
-      //   textItem: {
-      //     primaryText: {
-      //        text: $r('app.string.button_settings')
-      //      }
-      //    },
-      //   suffixItem: new SuffixArrow({}),
-      //    onClick: () => {
-      //      this.isSettingSheetVisible = true;
-      //    }
-      //  })
-      //    .bindSheet($$this.isSettingSheetVisible, this.SettingSheetBuilder(), {
-      //     detents: [SheetSize.LARGE],
-      //     preferType: SheetType.BOTTOM,
-      //     title: { title: $r('app.string.button_settings') },
-      //   })
-      //}
+      // 顶部占位空间，用于触发渐变模糊效果
+      ListItem() {
+        Column()
+          .width('100%')
+          .height(LengthMetrics.vp(120).value)
+      }
       // 备份与迁移入口
       ListItem() {
         HdsListItemCard({
@@ -648,7 +627,6 @@ struct Index {
 
     }
 
-    .padding({top: LengthMetrics.vp(120)})
     .width('100%')
     .height('100%')
     .scrollBar(BarState.Off)

--- a/entry/src/main/ets/pages/Index.ets
+++ b/entry/src/main/ets/pages/Index.ets
@@ -11,7 +11,7 @@ import { util } from '@kit.ArkTS';
 import { fileIo as fs } from '@kit.CoreFileKit';
 import { BusinessError, systemDateTime } from '@kit.BasicServicesKit';
 import { showSnackBar, SnackBarNotifyType } from '../utils/HdsSnackBarUtils';
-import { AppPreference, TokenPreference } from '../utils/AppPreference';
+import { AppPreference, TokenPreference,SettingTopEffectType,SettingBottomTabsType } from '../utils/AppPreference';
 import { privacyManager } from '@kit.StoreKit';
 import { hilog } from '@kit.PerformanceAnalysisKit';
 import CommonEventManager from '@ohos.commonEventManager';

--- a/entry/src/main/ets/pages/setting/AppearanceSheet.ets
+++ b/entry/src/main/ets/pages/setting/AppearanceSheet.ets
@@ -2,7 +2,7 @@ import { BusinessError } from '@kit.BasicServicesKit';
 import { showSnackBar, SnackBarNotifyType } from '../../utils/HdsSnackBarUtils';
 import { SubItemToggle } from '../../components/SubItemToggle'
 import { AppStorageV2, curves, router } from '@kit.ArkUI';
-import { AppPreference, SettingColorMode, TokenPreference } from '../../utils/AppPreference';
+import { AppPreference, SettingColorMode,SettingTopEffectType,SettingBottomTabsType, TokenPreference } from '../../utils/AppPreference';
 import { SubItemButton } from '../../components/SubItemButton';
 import { SettingItem } from '../../components/SettingItem';
 import { SubItemDivider } from '../../components/SubItemDivider';
@@ -98,6 +98,35 @@ export struct AppearanceSheet {
             .onClick(throttle((event) => {
               router.pushUrl({ url: 'pages/AppearancePage' });
             }, 1000))
+          SubItemDivider()
+
+          SubItemSelect({
+            icon: $r('sys.symbol.slider_horizontal_2'),
+            title: $r('app.string.setting_top_effect_type'),
+            values: [$r('app.string.setting_top_effect_type_disable'), $r('app.string.setting_top_effect_type_common_blur'),
+              $r('app.string.setting_top_effect_type_gradual_blur'), $r('app.string.setting_top_effect_type_gradient_blur'),
+              ],//$r('app.string.setting_top_effect_type_immersive_gradient_blur') 沉浸式渐变模糊需要api23 现在不支持
+            description: $r('app.string.setting_top_effect_type_desc'),
+            selected: AppPreference.getPreference('app_appearance_top_effect_type') as number ??
+            SettingTopEffectType.GRADUAL_BLUR,
+            onChange: (index: number) => {
+              AppPreference.setPreference('app_appearance_top_effect_type', index);
+            }
+          })
+
+          SubItemDivider()
+
+          SubItemSelect({
+            icon: $r('sys.symbol.slider_horizontal_2'),
+            title: $r('app.string.setting_bottom_tabs_type'),
+            values: [$r('app.string.setting_bottom_tabs_type_flatten'), $r('app.string.setting_bottom_tabs_type_suspension')],
+            description: $r('app.string.setting_bottom_tabs_type_desc'),
+            selected: AppPreference.getPreference('app_appearance_bottom_tabs_type') as number ??
+            SettingBottomTabsType.FLATTEN,
+            onChange: (index: number) => {
+              AppPreference.setPreference('app_appearance_bottom_tabs_type', index);
+            }
+          })
         }
       }
       .padding({ left: 10, right: 10 })

--- a/entry/src/main/ets/utils/AppPreference.ets
+++ b/entry/src/main/ets/utils/AppPreference.ets
@@ -7,6 +7,19 @@ export enum SettingColorMode {
   Dark,
   Light,
 }
+//顶部模糊类型
+export enum SettingTopEffectType {
+  DISABLE,//关闭
+  COMMON_BLUR,//通用模糊
+  GRADUAL_BLUR,//过渡模糊
+  GRADIENT_BLUR,//渐变模糊
+  IMMERSIVE_GRADIENT_BLUR//沉浸式渐变模糊 Api23
+}
+//底部Tabs类型
+export enum SettingBottomTabsType {
+  FLATTEN,//平铺
+  SUSPENSION,//悬浮
+}
 
 @ObservedV2
 export class TokenPreference {
@@ -117,7 +130,11 @@ export class AppPreference {
     ['app_appearance_issuer_font_weight', 400],
     ['app_appearance_user_name_font_size', 10],
     ['app_appearance_user_name_font_weight', 400],
-    ['app_appearance_item_max_width', 800]
+    ['app_appearance_item_max_width', 800],
+    // 外观-顶部模糊类型
+    ['app_appearance_top_effect_type', SettingTopEffectType.GRADUAL_BLUR],
+    // 外观-底部Tabs类型
+    ['app_appearance_bottom_tabs_type', SettingBottomTabsType.FLATTEN]
   ]);
 
   private static settings: Map<string, SettingValue> = new Map<string, SettingValue>([

--- a/entry/src/main/resources/en_US/element/string.json
+++ b/entry/src/main/resources/en_US/element/string.json
@@ -803,6 +803,50 @@
     {
       "name": "app_wearable_guide_msg",
       "value": "Sync tokens from other devices"
+    },
+    {
+      "name": "setting_top_effect_type",
+      "value": "Top Blur Type"
+    },
+    {
+      "name": "setting_top_effect_type_desc",
+      "value": "Control the type of top blur effect"
+    },
+    {
+      "name": "setting_top_effect_type_disable",
+      "value": "Disabled"
+    },
+    {
+      "name": "setting_top_effect_type_common_blur",
+      "value": "Common Blur"
+    },
+    {
+      "name": "setting_top_effect_type_gradual_blur",
+      "value": "Gradual Blur"
+    },
+    {
+      "name": "setting_top_effect_type_gradient_blur",
+      "value": "Gradient Blur"
+    },
+    {
+      "name": "setting_top_effect_type_immersive_gradient_blur",
+      "value": "Immersive Gradient Blur"
+    },
+    {
+      "name": "setting_bottom_tabs_type",
+      "value": "Bottom Tabs Type"
+    },
+    {
+      "name": "setting_bottom_tabs_type_desc",
+      "value": "Control the display type of bottom tab bar"
+    },
+    {
+      "name": "setting_bottom_tabs_type_flatten",
+      "value": "Flatten"
+    },
+    {
+      "name": "setting_bottom_tabs_type_suspension",
+      "value": "Suspension"
     }
   ]
 }

--- a/entry/src/main/resources/zh_CN/element/string.json
+++ b/entry/src/main/resources/zh_CN/element/string.json
@@ -803,6 +803,50 @@
     {
       "name": "app_wearable_guide_msg",
       "value": "从其他设备同步令牌"
+    },
+    {
+      "name": "setting_top_effect_type",
+      "value": "顶部模糊类型"
+    },
+    {
+      "name": "setting_top_effect_type_desc",
+      "value": "控制顶部模糊效果的类型"
+    },
+    {
+      "name": "setting_top_effect_type_disable",
+      "value": "关闭"
+    },
+    {
+      "name": "setting_top_effect_type_common_blur",
+      "value": "通用模糊"
+    },
+    {
+      "name": "setting_top_effect_type_gradual_blur",
+      "value": "过渡模糊"
+    },
+    {
+      "name": "setting_top_effect_type_gradient_blur",
+      "value": "渐变模糊"
+    },
+    {
+      "name": "setting_top_effect_type_immersive_gradient_blur",
+      "value": "沉浸式渐变模糊"
+    },
+    {
+      "name": "setting_bottom_tabs_type",
+      "value": "底部Tabs类型"
+    },
+    {
+      "name": "setting_bottom_tabs_type_desc",
+      "value": "控制底部标签栏的显示类型"
+    },
+    {
+      "name": "setting_bottom_tabs_type_flatten",
+      "value": "平铺"
+    },
+    {
+      "name": "setting_bottom_tabs_type_suspension",
+      "value": "悬浮"
     }
   ]
 }

--- a/entry/src/main/resources/zh_TW/element/string.json
+++ b/entry/src/main/resources/zh_TW/element/string.json
@@ -803,6 +803,50 @@
     {
       "name": "app_wearable_guide_msg",
       "value": "從其他設備同步令牌"
+    },
+    {
+      "name": "setting_top_effect_type",
+      "value": "頂部模糊類型"
+    },
+    {
+      "name": "setting_top_effect_type_desc",
+      "value": "控制頂部模糊效果的類型"
+    },
+    {
+      "name": "setting_top_effect_type_disable",
+      "value": "關閉"
+    },
+    {
+      "name": "setting_top_effect_type_common_blur",
+      "value": "通用模糊"
+    },
+    {
+      "name": "setting_top_effect_type_gradual_blur",
+      "value": "過渡模糊"
+    },
+    {
+      "name": "setting_top_effect_type_gradient_blur",
+      "value": "漸變模糊"
+    },
+    {
+      "name": "setting_top_effect_type_immersive_gradient_blur",
+      "value": "沉浸式漸變模糊"
+    },
+    {
+      "name": "setting_bottom_tabs_type",
+      "value": "底部Tabs類型"
+    },
+    {
+      "name": "setting_bottom_tabs_type_desc",
+      "value": "控制底部標籤欄的顯示類型"
+    },
+    {
+      "name": "setting_bottom_tabs_type_flatten",
+      "value": "平鋪"
+    },
+    {
+      "name": "setting_bottom_tabs_type_suspension",
+      "value": "懸浮"
     }
   ]
 }


### PR DESCRIPTION
<img width="494" height="1066" alt="image" src="https://github.com/user-attachments/assets/6667ab27-8f39-4b8b-9141-9b9d52a841a4" />

本提交是 #96 的一部分 因为index主页有其他pr有较大变更，目前个性化选项只实现了设置 需要等待pr #108 合并后才能施工实现效果