### PR TITLE
[fix:#80] 自定义图标选择支持图片裁剪与圆角显示

### DIFF
--- a/entry/src/main/ets/components/ArcTokenIcon.ets
+++ b/entry/src/main/ets/components/ArcTokenIcon.ets
@@ -127,11 +127,13 @@ export struct ArcTokenIcon {
             .width(this.token_preference.app_appearance_logo_size)
             .fillColor(this.token_preference.app_appearance_logo_dark_filter_color)
             .objectFit(ImageFit.Contain)
+            .borderRadius(20)
         } else {
           Image(this.icon)
             .height(this.token_preference.app_appearance_logo_size)
             .width(this.token_preference.app_appearance_logo_size)
             .objectFit(ImageFit.Contain)
+            .borderRadius(20)
         }
       }
     }

--- a/entry/src/main/ets/components/ArcTokenIcon.ets
+++ b/entry/src/main/ets/components/ArcTokenIcon.ets
@@ -23,6 +23,11 @@ export struct ArcTokenIcon {
     return true;
   }
 
+  @Computed
+  get iconRadius(): number {
+    return TokenIconPacks.user_added_icon_packs.raster_icons.has(this.icon_path) ? 20 : 0;
+  }
+
   @Monitor("issuer")
   onStrChange(monitor: IMonitor) {
     monitor.dirty.forEach((path: string) => {
@@ -127,13 +132,13 @@ export struct ArcTokenIcon {
             .width(this.token_preference.app_appearance_logo_size)
             .fillColor(this.token_preference.app_appearance_logo_dark_filter_color)
             .objectFit(ImageFit.Contain)
-            .borderRadius(20)
+            .borderRadius(this.iconRadius)
         } else {
           Image(this.icon)
             .height(this.token_preference.app_appearance_logo_size)
             .width(this.token_preference.app_appearance_logo_size)
             .objectFit(ImageFit.Contain)
-            .borderRadius(20)
+            .borderRadius(this.iconRadius)
         }
       }
     }

--- a/entry/src/main/ets/components/ImageCropView.ets
+++ b/entry/src/main/ets/components/ImageCropView.ets
@@ -1,0 +1,330 @@
+import { image } from '@kit.ImageKit';
+import common2D from '@ohos.graphics.common2D';
+import Matrix4 from '@ohos.matrix4';
+import { fileIo } from '@kit.CoreFileKit';
+import { hilog } from '@kit.PerformanceAnalysisKit';
+
+interface ImageLoadedEvent {
+  width: number;
+  height: number;
+  componentWidth: number;
+  componentHeight: number;
+  loadingStatus: number;
+  contentWidth: number;
+  contentHeight: number;
+  contentOffsetX: number;
+  contentOffsetY: number;
+}
+
+interface ImageLoadEventListener {
+  onImageLoaded(msg: ImageLoadedEvent): void;
+  onImageLoadError(error: ImageError): void;
+}
+
+/**
+ * 图片裁剪模型，参考 PersonalInfoUpload 项目的 ImageCrop 实现
+ * 管理裁剪参数（图片源、取景框尺寸/比例、手势偏移/缩放），提供 crop() 方法执行裁剪
+ * 裁剪流程: 打开源文件 -> ImageSource -> PixelMap深拷贝(BGRA→RGBA) -> cropSync(裁剪区域) -> 返回PixelMap
+ * 注: 裁剪输出为正方形/矩形图片，圆形效果需在UI层通过 .borderRadius() 实现
+ */
+export class CropModel {
+  src: string = '';
+  previewSource: string | Resource = '';
+  panEnabled: boolean = true;
+  zoomEnabled: boolean = true;
+  frameWidth: number = 1000;
+  frameRatio: number = 1;
+  maskColor: string = '#AA000000';
+  strokeColor: string = '#FFFFFF';
+  imageLoadEventListener: ImageLoadEventListener | null = null;
+  imageWidth: number = 0;
+  imageHeight: number = 0;
+  componentWidth: number = 0;
+  componentHeight: number = 0;
+  scale: number = 1;
+  offsetX: number = 0;
+  offsetY: number = 0;
+
+  public setImage(src: string, previewSource?: string | Resource): CropModel {
+    this.src = src;
+    if (!!previewSource) {
+      this.previewSource = previewSource;
+    }
+    return this;
+  }
+
+  public setFrameWidth(frameWidth: number): CropModel {
+    this.frameWidth = frameWidth;
+    return this;
+  }
+
+  public setFrameRatio(frameRatio: number): CropModel {
+    this.frameRatio = frameRatio;
+    return this;
+  }
+
+  public getFrameHeight(): number {
+    return this.frameWidth / this.frameRatio;
+  }
+
+  public reset(): void {
+    this.scale = 1;
+    this.offsetX = 0;
+    this.offsetY = 0;
+  }
+
+  /**
+   * 执行图片裁剪
+   * 1. 计算图片适配控件缩放比(adaptScale)与手势缩放比(scale)的总缩放(totalScale)
+   * 2. 根据取景框在组件中的位置，反算出原图中对应的裁剪区域(Region)
+   * 3. 打开文件 -> ImageSource -> PixelMap(BGRA_8888) -> 深拷贝为RGBA_8888 -> cropSync裁剪
+   * @returns 裁剪后的 PixelMap
+   */
+  public async crop(): Promise<image.PixelMap> {
+    if (!this.src || this.src === '') {
+      throw new Error('Please set src first');
+    }
+    if (this.imageWidth === 0 || this.imageHeight === 0) {
+      throw new Error('The image is not loaded');
+    }
+
+    let widthScale = this.componentWidth / this.imageWidth;
+    let heightScale = this.componentHeight / this.imageHeight;
+    let adaptScale = Math.min(widthScale, heightScale);
+
+    let totalScale = adaptScale * this.scale;
+    let showWidth = this.imageWidth * totalScale;
+    let showHeight = this.imageHeight * totalScale;
+    let imageX = (this.componentWidth - showWidth) / 2;
+    let imageY = (this.componentHeight - showHeight) / 2;
+
+    let frameX = (this.componentWidth - this.frameWidth) / 2;
+    let frameY = (this.componentHeight - this.getFrameHeight()) / 2;
+
+    let showX = imageX + this.offsetX * this.scale;
+    let showY = imageY + this.offsetY * this.scale;
+    let x = (frameX - showX) / totalScale;
+    let y = (frameY - showY) / totalScale;
+
+    let file = fileIo.openSync(this.src, fileIo.OpenMode.READ_ONLY);
+    let imageSource: image.ImageSource = image.createImageSource(file.fd);
+    let decodingOptions: image.DecodingOptions = {
+      editable: true,
+      desiredPixelFormat: image.PixelMapFormat.BGRA_8888,
+    };
+    let pm = await imageSource.createPixelMap(decodingOptions);
+    let cp = await this.copyPixelMap(pm);
+    pm.release();
+
+    let region: image.Region =
+      { x: x, y: y, size: { width: this.frameWidth / totalScale, height: this.getFrameHeight() / totalScale } };
+    cp.cropSync(region);
+
+    fileIo.closeSync(file);
+    await imageSource.release();
+    return cp;
+  }
+
+  async copyPixelMap(pm: PixelMap): Promise<PixelMap> {
+    const imageInfo: image.ImageInfo = await pm.getImageInfo();
+    const buffer: ArrayBuffer = new ArrayBuffer(pm.getPixelBytesNumber());
+    await pm.readPixelsToBuffer(buffer);
+    const opts: image.InitializationOptions = {
+      editable: true,
+      pixelFormat: image.PixelMapFormat.RGBA_8888,
+      size: { height: imageInfo.size.height, width: imageInfo.size.width }
+    };
+    return image.createPixelMap(buffer, opts);
+  }
+}
+
+/**
+ * 图片裁剪视图组件
+ * 上层: Image组件显示源图片，通过Matrix4变换实现拖动/缩放
+ * 下层: Canvas绘制半透明遮罩 + 圆形取景框（纯视觉引导，不影响裁剪结果）
+ * 手势: 拖动(PanGesture)平移图片、双指缩放(PinchGesture)、双击切换1x/2x
+ */
+@Component
+export struct CropView {
+  @State model: CropModel = new CropModel();
+  private settings: RenderingContextSettings = new RenderingContextSettings(true);
+  private context: CanvasRenderingContext2D = new CanvasRenderingContext2D(this.settings);
+  @State private matrix: object = Matrix4.identity()
+    .translate({ x: 0, y: 0 })
+    .scale({ x: this.model.scale, y: this.model.scale });
+  private tempScale: number = 1;
+  private startOffsetX: number = 0;
+  private startOffsetY: number = 0;
+
+  build() {
+    Stack() {
+      Image(this.model.src)
+        .width('100%')
+        .height('100%')
+        .alt(this.model.previewSource)
+        .objectFit(ImageFit.Contain)
+        .transform(this.matrix)
+        .onComplete((msg) => {
+          if (msg) {
+            this.model.imageWidth = msg.width;
+            this.model.imageHeight = msg.height;
+            this.model.componentWidth = msg.componentWidth;
+            this.model.componentHeight = msg.componentHeight;
+            this.checkImageAdapt();
+          }
+        })
+        .onError((error) => {
+          hilog.error(0, 'CropView', 'Image load error: ' + JSON.stringify(error));
+        });
+      Canvas(this.context)
+        .width('100%')
+        .height('100%')
+        .backgroundColor(Color.Transparent)
+        .onReady(() => {
+          if (this.context == null) {
+            return;
+          }
+          let height = this.context.height;
+          let width = this.context.width;
+          this.context.fillStyle = this.model.maskColor;
+          this.context.fillRect(0, 0, width, height);
+
+          let centerX = width / 2;
+          let centerY = height / 2;
+
+          this.context.globalCompositeOperation = 'destination-out';
+          this.context.fillStyle = 'white';
+          this.context.beginPath();
+          this.context.arc(centerX, centerY, this.getUIContext().px2vp(this.model.frameWidth / 2), 0, 2 * Math.PI);
+          this.context.fill();
+
+          this.context.globalCompositeOperation = 'source-over';
+          this.context.strokeStyle = this.model.strokeColor;
+          let frameWidthInVp = this.getUIContext().px2vp(this.model.frameWidth);
+          let frameHeightInVp = this.getUIContext().px2vp(this.model.getFrameHeight());
+          let radius = Math.min(frameWidthInVp, frameHeightInVp) / 2;
+          this.context.beginPath();
+          this.context.arc(centerX, centerY, radius, 0, 2 * Math.PI);
+          this.context.closePath();
+          this.context.lineWidth = 1;
+          this.context.stroke();
+        })
+        .enabled(false);
+    }
+    .clip(true)
+    .width('100%')
+    .height('100%')
+    .backgroundColor('#00000080')
+    .priorityGesture(
+      TapGesture({ count: 2, fingers: 1 })
+        .onAction((event: GestureEvent) => {
+          if (!event) {
+            return;
+          }
+          if (this.model.zoomEnabled) {
+            if (this.model.scale !== 1) {
+              this.model.scale = 1;
+              this.model.reset();
+              this.updateMatrix();
+            } else {
+              this.zoomTo(2);
+            }
+          }
+          this.checkImageAdapt();
+        })
+    )
+    .gesture(
+      GestureGroup(GestureMode.Parallel,
+        PanGesture({})
+          .onActionStart(() => {
+            this.startOffsetX = this.model.offsetX;
+            this.startOffsetY = this.model.offsetY;
+          })
+          .onActionUpdate((event: GestureEvent) => {
+            if (event) {
+              if (this.model.panEnabled) {
+                let distanceX: number = this.startOffsetX + this.getUIContext().vp2px(event.offsetX) / this.model.scale;
+                let distanceY: number = this.startOffsetY + this.getUIContext().vp2px(event.offsetY) / this.model.scale;
+                this.model.offsetX = distanceX;
+                this.model.offsetY = distanceY;
+                this.updateMatrix();
+              }
+            }
+          })
+          .onActionEnd(() => {
+            this.checkImageAdapt();
+          }),
+        PinchGesture({ fingers: 2 })
+          .onActionStart(() => {
+            this.tempScale = this.model.scale;
+          })
+          .onActionUpdate((event) => {
+            if (event) {
+              if (!this.model.zoomEnabled) {
+                return;
+              }
+              this.zoomTo(this.tempScale * event.scale);
+            }
+          })
+          .onActionEnd(() => {
+            this.checkImageAdapt();
+          })
+      )
+    );
+  }
+
+  private checkImageAdapt() {
+    let offsetX = this.model.offsetX;
+    let offsetY = this.model.offsetY;
+    let scale = this.model.scale;
+
+    let widthScale = this.model.componentWidth / this.model.imageWidth;
+    let heightScale = this.model.componentHeight / this.model.imageHeight;
+    let adaptScale = Math.min(widthScale, heightScale);
+
+    let showWidth = this.model.imageWidth * adaptScale * this.model.scale;
+    let showHeight = this.model.imageHeight * adaptScale * this.model.scale;
+    let imageX = (this.model.componentWidth - showWidth) / 2;
+    let imageY = (this.model.componentHeight - showHeight) / 2;
+
+    let frameX = (this.model.componentWidth - this.model.frameWidth) / 2;
+    let frameY = (this.model.componentHeight - this.model.getFrameHeight()) / 2;
+
+    let showX = imageX + offsetX * scale;
+    let showY = imageY + offsetY * scale;
+
+    if (this.model.frameWidth > showWidth || this.model.getFrameHeight() > showHeight) {
+      let xScale = this.model.frameWidth / showWidth;
+      let yScale = this.model.getFrameHeight() / showHeight;
+      let newScale = Math.max(xScale, yScale);
+      this.model.scale = this.model.scale * newScale;
+      showX *= newScale;
+      showY *= newScale;
+    }
+
+    if (showX > frameX) {
+      showX = frameX;
+    } else if (showX + showWidth < frameX + this.model.frameWidth) {
+      showX = frameX + this.model.frameWidth - showWidth;
+    }
+    if (showY > frameY) {
+      showY = frameY;
+    } else if (showY + showHeight < frameY + this.model.getFrameHeight()) {
+      showY = frameY + this.model.getFrameHeight() - showHeight;
+    }
+    this.model.offsetX = (showX - imageX) / scale;
+    this.model.offsetY = (showY - imageY) / scale;
+    this.updateMatrix();
+  }
+
+  public zoomTo(scale: number): void {
+    this.model.scale = scale;
+    this.updateMatrix();
+  }
+
+  public updateMatrix(): void {
+    this.matrix = Matrix4.identity()
+      .translate({ x: this.model.offsetX, y: this.model.offsetY })
+      .scale({ x: this.model.scale, y: this.model.scale });
+  }
+}

--- a/entry/src/main/ets/components/TokenIcon.ets
+++ b/entry/src/main/ets/components/TokenIcon.ets
@@ -127,11 +127,13 @@ export struct TokenIcon {
             .width(this.token_preference.app_appearance_logo_size)
             .fillColor(this.token_preference.app_appearance_logo_dark_filter_color)
             .objectFit(ImageFit.Contain)
+            .borderRadius(20)
         } else {
           Image(this.icon)
             .height(this.token_preference.app_appearance_logo_size)
             .width(this.token_preference.app_appearance_logo_size)
             .objectFit(ImageFit.Contain)
+            .borderRadius(20)
         }
       }
     }

--- a/entry/src/main/ets/components/TokenIcon.ets
+++ b/entry/src/main/ets/components/TokenIcon.ets
@@ -23,6 +23,11 @@ export struct TokenIcon {
     return this.window.ColorMode == ConfigurationConstant.ColorMode.COLOR_MODE_DARK;
   }
 
+  @Computed
+  get iconRadius(): number {
+    return TokenIconPacks.user_added_icon_packs.raster_icons.has(this.icon_path) ? 20 : 0;
+  }
+
   @Monitor("issuer")
   onStrChange(monitor: IMonitor) {
     monitor.dirty.forEach((path: string) => {
@@ -127,13 +132,13 @@ export struct TokenIcon {
             .width(this.token_preference.app_appearance_logo_size)
             .fillColor(this.token_preference.app_appearance_logo_dark_filter_color)
             .objectFit(ImageFit.Contain)
-            .borderRadius(20)
+            .borderRadius(this.iconRadius)
         } else {
           Image(this.icon)
             .height(this.token_preference.app_appearance_logo_size)
             .width(this.token_preference.app_appearance_logo_size)
             .objectFit(ImageFit.Contain)
-            .borderRadius(20)
+            .borderRadius(this.iconRadius)
         }
       }
     }

--- a/entry/src/main/ets/dialogs/SelectIconDialog.ets
+++ b/entry/src/main/ets/dialogs/SelectIconDialog.ets
@@ -1,8 +1,11 @@
 import { TokenIcon } from "../components/TokenIcon";
+import { CropModel, CropView } from "../components/ImageCropView";
+import { getImageDimensions, savePixelMapToFile, copyFileToDir } from "../utils/PhotoPickerUtils";
 import { showSelectFilePicker } from "../utils/FileUtils";
 import { AegisIconPack, TokenIconPacks } from "../utils/TokenUtils";
-import { fileIo } from "@kit.CoreFileKit";
 import { hilog } from '@kit.PerformanceAnalysisKit';
+
+const MAX_ICON_SIZE = 256;
 
 @Preview
 @CustomDialog
@@ -17,6 +20,9 @@ export struct SelectIconDialog {
   @State icon_matched_with_issuer: string[] = [''];
   @State default_icon_pack_visible: boolean = true;
   @State aegis_icon_pack_visible: boolean[] = [];
+  @State showCropCover: boolean = false;
+  @State cropModel: CropModel = new CropModel();
+  @State pendingCropUri: string = '';
 
   private default_icon_data: MyDataSource = new MyDataSource();
   private user_icon_data: MyDataSource = new MyDataSource();
@@ -131,6 +137,13 @@ export struct SelectIconDialog {
     .margin({ left: 10 })
   }
 
+  /**
+   * 自定义图标添加按钮
+   * 流程: DocumentViewPicker选择文件 -> getImageDimensions获取尺寸
+   * - 尺寸 > 128x128: 通过bindContentCover弹出裁剪界面(CropView)，裁剪后保存
+   * - 尺寸 <= 128x128: 直接复制到用户图标目录
+   * - 无法获取尺寸(SVG等): 降级直接复制
+   */
   @Builder
   ItemIconAddButton() {
     ListItem() {
@@ -144,17 +157,88 @@ export struct SelectIconDialog {
       .shadow({ radius: 10, color: Color.Gray })
       .width(40)
       .height(40)
-      .onClick(() => {
-        showSelectFilePicker(1, ["PNG|.png", "JPEG|.jpg", "SVG|.svg"]).then((uris) => {
-          fileIo.open(uris[0]).then((file) => {
-            TokenIconPacks.user_added_icon_packs.addIcon(file);
-            this.user_icon_data.pushData(TokenIconPacks.user_added_icon_packs.latest_icon_path);
-          });
-
-        });
+      .onClick(async () => {
+        try {
+          const uris = await showSelectFilePicker(1, ['png', 'jpg', 'jpeg', 'svg', 'webp']);
+          if (uris.length === 0) {
+            return;
+          }
+          const uri = uris[0];
+          const isSvg = uri.toLowerCase().endsWith('.svg');
+          if (isSvg) {
+            const destPath = await copyFileToDir(uri, TokenIconPacks.user_added_icon_packs.user_icon_path);
+            TokenIconPacks.user_added_icon_packs.addIconByPath(destPath);
+            this.user_icon_data.pushData(destPath);
+            return;
+          }
+          const dims = await getImageDimensions(uri);
+          if (dims === null) {
+            hilog.warn(0, 'SelectIconDialog', 'Cannot get image dimensions, copying directly');
+            const destPath = await copyFileToDir(uri, TokenIconPacks.user_added_icon_packs.user_icon_path);
+            TokenIconPacks.user_added_icon_packs.addIconByPath(destPath);
+            this.user_icon_data.pushData(destPath);
+            return;
+          }
+          if (dims.width > MAX_ICON_SIZE || dims.height > MAX_ICON_SIZE) {
+            this.pendingCropUri = uri;
+            this.cropModel = new CropModel();
+            this.cropModel.setImage(uri).setFrameWidth(1000).setFrameRatio(1);
+            this.showCropCover = true;
+          } else {
+            const destPath = await copyFileToDir(uri, TokenIconPacks.user_added_icon_packs.user_icon_path);
+            TokenIconPacks.user_added_icon_packs.addIconByPath(destPath);
+            this.user_icon_data.pushData(destPath);
+          }
+        } catch (e) {
+          hilog.error(0, 'SelectIconDialog', 'Add icon error: ' + JSON.stringify(e));
+        }
       })
     }
     .margin({ left: 10 })
+  }
+
+  /**
+   * 图片裁剪全屏覆盖层
+   * 使用CropView显示图片+圆形取景框，用户通过拖动/缩放调整裁剪区域
+   * 确认后: cropModel.crop()裁剪PixelMap -> savePixelMapToFile()保存PNG到用户图标目录
+   */
+  @Builder
+  CropCoverBuilder() {
+    Column() {
+      CropView({ model: this.cropModel })
+        .layoutWeight(1)
+        .width('100%')
+
+      Row() {
+        Button($r('app.string.dialog_btn_cancel'))
+          .fontColor(Color.White)
+          .backgroundColor(Color.Transparent)
+          .layoutWeight(1)
+          .onClick(() => {
+            this.showCropCover = false;
+          })
+        Button($r('app.string.dialog_btn_confirm'))
+          .fontColor(Color.White)
+          .backgroundColor(Color.Transparent)
+          .layoutWeight(1)
+          .onClick(async () => {
+            try {
+              const pm: PixelMap = await this.cropModel.crop();
+              const destPath = await savePixelMapToFile(pm, TokenIconPacks.user_added_icon_packs.user_icon_path);
+              TokenIconPacks.user_added_icon_packs.addIconByPath(destPath);
+              this.user_icon_data.pushData(destPath);
+              this.showCropCover = false;
+            } catch (e) {
+              hilog.error(0, 'SelectIconDialog', 'Crop error: ' + JSON.stringify(e));
+            }
+          })
+      }
+      .width('100%')
+      .padding({ left: 20, right: 20, bottom: 30 })
+    }
+    .width('100%')
+    .height('100%')
+    .backgroundColor(Color.Black)
   }
 
   build() {
@@ -226,6 +310,12 @@ export struct SelectIconDialog {
     }
     .padding(10)
     .width('100%')
+    .bindContentCover(this.showCropCover, this.CropCoverBuilder(), {
+      modalTransition: ModalTransition.DEFAULT,
+      onDisappear: () => {
+        this.showCropCover = false;
+      }
+    })
   }
 }
 

--- a/entry/src/main/ets/pages/ShowDataSyncDetailsPage.ets
+++ b/entry/src/main/ets/pages/ShowDataSyncDetailsPage.ets
@@ -1,12 +1,12 @@
 import { AppStorageV2 } from '@kit.ArkUI';
 import { TopNavigationView } from '../components/TopNavigationView';
 import { SettingItem } from '../components/SettingItem';
-import { deviceInfo } from '@kit.BasicServicesKit';
 import { AppPreference, SettingValue, PREF_KEYS } from '../utils/AppPreference';
 import { SubItemButton } from '../components/SubItemButton';
 import { TokenStore } from '../utils/TokenStore';
 import { SubItemDivider } from '../components/SubItemDivider';
 import { AppWindowInfo } from '../entryability/EntryAbility';
+import { DeviceInfoHelper,DeviceInfoData } from '../utils/DeviceInfoHelper';
 
 @Entry
 @Preview
@@ -17,6 +17,8 @@ export struct ShowDataSyncDetailsPage {
   @Local AppDbKVArchiveTime: SettingValue = '';
   @Local Is_loaded: boolean = false;
   @Local window: AppWindowInfo = AppStorageV2.connect(AppWindowInfo) as AppWindowInfo;
+  @Local deviceName: string = '';
+  @Local deviceId: string = '';
 
   aboutToAppear(): void {
     this.AppDbKVSyncTime = AppPreference.getPreference(PREF_KEYS.DB_KV_SYNC_TIME);
@@ -27,6 +29,10 @@ export struct ShowDataSyncDetailsPage {
     if (this.AppDbKVArchiveTime == '' || this.AppDbKVArchiveTime == null) {
       this.AppDbKVArchiveTime = 'invalid';
     }
+
+    const deviceInfo:DeviceInfoData = DeviceInfoHelper.getInstance().getDeviceInfo();
+    this.deviceName = deviceInfo.marketName;
+    this.deviceId = deviceInfo.odid;
   }
 
   build() {
@@ -59,7 +65,7 @@ export struct ShowDataSyncDetailsPage {
               ListItem() {
                 SettingItem({ title: $r('app.string.data_dev_info') }) {
                   Row() {
-                    Text(deviceInfo.marketName)
+                    Text(this.deviceName)
                       .fontSize($r('sys.float.ohos_id_text_size_body2'))
                       .fontColor($r('sys.color.ohos_id_color_text_primary'))
                       .fontWeight(FontWeight.Medium)
@@ -70,7 +76,7 @@ export struct ShowDataSyncDetailsPage {
                   SubItemDivider()
 
                   Row() {
-                    Text(deviceInfo.ODID)
+                    Text(this.deviceId)
                       .fontSize($r('sys.float.ohos_id_text_size_body2'))
                       .fontColor($r('sys.color.ohos_id_color_text_primary'))
                       .fontWeight(FontWeight.Medium)

--- a/entry/src/main/ets/utils/DeviceInfoHelper.ets
+++ b/entry/src/main/ets/utils/DeviceInfoHelper.ets
@@ -1,0 +1,240 @@
+/*
+ * Copyright (c) 2023-2024 ohtotptoken Project Contributors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * 设备信息帮助类
+ * 
+ * 提供设备信息的获取和缓存功能。
+ * 根据华为开发者文档，deviceInfo 模块返回设备常量信息，
+ * 建议应用只调用一次，不需要频繁调用。
+ * 
+ * 本类采用单例模式，在应用启动时调用 init() 方法初始化设备信息，
+ * 然后将设备信息缓存到 AppStorage，后续通过 getter 方法获取。
+ * 
+ * @module DeviceInfoHelper
+ */
+
+import { deviceInfo } from '@kit.BasicServicesKit';
+import { AppStorageV2 } from '@kit.ArkUI';
+import { hilog } from '@kit.PerformanceAnalysisKit';
+
+const TAG = 'DeviceInfoHelper';
+const DOMAIN = 0xFF00;
+
+/**
+ * 设备信息缓存键
+ */
+const DEVICE_INFO_KEY = 'cached_device_info';
+
+/**
+ * 设备信息接口
+ */
+export interface DeviceInfoData {
+  /** 开发者匿名设备标识符（可作为设备唯一标识） */
+  odid: string;
+  /** 设备类型 */
+  deviceType: string;
+  /** 设备厂家名称 */
+  manufacture: string;
+  /** 设备品牌名称 */
+  brand: string;
+  /** 外部产品系列 */
+  marketName: string;
+  /** 产品系列 */
+  productSeries: string;
+  /** 认证型号 */
+  productModel: string;
+  /** 内部软件子型号 */
+  softwareModel: string;
+  /** 硬件版本号 */
+  hardwareModel: string;
+  /** 应用二进制接口 */
+  abiList: string;
+  /** 安全补丁级别 */
+  securityPatchTag: string;
+  /** 产品版本 */
+  displayVersion: string;
+  /** 系统发布类型 */
+  osReleaseType: string;
+  /** 系统版本 */
+  osFullName: string;
+  /** 发行版系统名称 */
+  distributionOSName: string;
+  /** 发行版系统版本号 */
+  distributionOSVersion: string;
+  /** 发行版系统API版本 */
+  distributionOSApiVersion: number;
+  /** 发行版系统类型 */
+  distributionOSReleaseType: string;
+}
+
+/**
+ * 设备信息帮助类
+ * 
+ * 使用示例：
+ * ```ts
+ * // 应用启动时初始化
+ * await DeviceInfoHelper.getInstance().init();
+ * 
+ * // 获取设备信息
+ * const deviceInfo = DeviceInfoHelper.getInstance().getDeviceInfo();
+ * console.log('Device ODID:', deviceInfo.odid);
+ * console.log('Device Name:', deviceInfo.marketName);
+ * ```
+ */
+export class DeviceInfoHelper {
+  /** 单例实例 */
+  private static instance: DeviceInfoHelper | null = null;
+  /** 设备信息缓存 */
+  private cachedDeviceInfo: DeviceInfoData | null = null;
+  /** 是否已初始化 */
+  private initialized: boolean = false;
+
+  private constructor() {
+  }
+
+  /**
+   * 获取 DeviceInfoHelper 单例实例
+   * @returns DeviceInfoHelper 实例
+   */
+  static getInstance(): DeviceInfoHelper {
+    if (!DeviceInfoHelper.instance) {
+      DeviceInfoHelper.instance = new DeviceInfoHelper();
+    }
+    return DeviceInfoHelper.instance;
+  }
+
+  /**
+   * 初始化设备信息
+   * 
+   * 从 deviceInfo 模块获取设备信息并缓存到 AppStorage。
+   * 根据华为开发者文档，此方法应在应用启动时调用一次。
+   * 
+   * @returns Promise<void>
+   */
+  async init(): Promise<void> {
+    if (this.initialized) {
+      hilog.info(DOMAIN, TAG, 'init: already initialized');
+      return;
+    }
+
+    try {
+      hilog.info(DOMAIN, TAG, 'init: collecting device info');
+
+      const deviceInfoData: DeviceInfoData = {
+        odid: deviceInfo.ODID || 'unknown_odid',
+        deviceType: deviceInfo.deviceType || 'unknown',
+        manufacture: deviceInfo.manufacture || 'unknown',
+        brand: deviceInfo.brand || 'unknown',
+        marketName: deviceInfo.marketName || 'Unknown Device',
+        productSeries: deviceInfo.productSeries || 'unknown',
+        productModel: deviceInfo.productModel || 'unknown',
+        softwareModel: deviceInfo.softwareModel || 'unknown',
+        hardwareModel: deviceInfo.hardwareModel || 'unknown',
+        abiList: deviceInfo.abiList || 'unknown',
+        securityPatchTag: deviceInfo.securityPatchTag || 'unknown',
+        displayVersion: deviceInfo.displayVersion || 'unknown',
+        osReleaseType: deviceInfo.osReleaseType || 'unknown',
+        osFullName: deviceInfo.osFullName || 'unknown',
+        distributionOSName: deviceInfo.distributionOSName || 'unknown',
+        distributionOSVersion: deviceInfo.distributionOSVersion || 'unknown',
+        distributionOSApiVersion: deviceInfo.distributionOSApiVersion || 0,
+        distributionOSReleaseType: deviceInfo.distributionOSReleaseType || 'unknown',
+      };
+
+      this.cachedDeviceInfo = deviceInfoData;
+      this.initialized = true;
+
+      // 缓存到 AppStorage
+      AppStorage.setOrCreate(DEVICE_INFO_KEY, deviceInfoData);
+
+      hilog.info(DOMAIN, TAG, `init: completed, ODID=${deviceInfoData.odid}, marketName=${deviceInfoData.marketName}`);
+    } catch (e) {
+      hilog.error(DOMAIN, TAG, `init: error=${JSON.stringify(e)}`);
+    }
+  }
+
+  /**
+   * 获取设备信息
+   * 
+   * @returns 设备信息对象，如果未初始化则返回默认值
+   */
+  getDeviceInfo(): DeviceInfoData {
+    if (this.cachedDeviceInfo) {
+      return this.cachedDeviceInfo;
+    }
+
+    // 尝试从 AppStorage 获取
+    const appStorageInfo = AppStorage.get<DeviceInfoData>(DEVICE_INFO_KEY);
+    if (appStorageInfo) {
+      this.cachedDeviceInfo = appStorageInfo;
+      return appStorageInfo;
+    }
+
+    // 返回默认值
+    hilog.warn(DOMAIN, TAG, 'getDeviceInfo: not initialized, returning default values');
+    return {
+      odid: 'unknown_odid',
+      deviceType: 'unknown',
+      manufacture: 'unknown',
+      brand: 'unknown',
+      marketName: 'Unknown Device',
+      productSeries: 'unknown',
+      productModel: 'unknown',
+      softwareModel: 'unknown',
+      hardwareModel: 'unknown',
+      abiList: 'unknown',
+      securityPatchTag: 'unknown',
+      displayVersion: 'unknown',
+      osReleaseType: 'unknown',
+      osFullName: 'unknown',
+      distributionOSName: 'unknown',
+      distributionOSVersion: 'unknown',
+      distributionOSApiVersion: 0,
+      distributionOSReleaseType: 'unknown',
+    };
+  }
+
+  /**
+   * 获取设备唯一标识符
+   * 
+   * 使用 ODID 作为设备唯一标识，无需权限。
+   * 
+   * @returns 设备唯一标识符
+   */
+  getDeviceId(): string {
+    return this.getDeviceInfo().odid;
+  }
+
+  /**
+   * 获取设备名称
+   * 
+   * 使用 marketName 作为设备名称。
+   * 
+   * @returns 设备名称
+   */
+  getDeviceName(): string {
+    return this.getDeviceInfo().marketName;
+  }
+
+  /**
+   * 检查是否已初始化
+   * 
+   * @returns 是否已初始化
+   */
+  isInitialized(): boolean {
+    return this.initialized;
+  }
+}

--- a/entry/src/main/ets/utils/PhotoPickerUtils.ets
+++ b/entry/src/main/ets/utils/PhotoPickerUtils.ets
@@ -1,0 +1,116 @@
+import { photoAccessHelper } from '@kit.MediaLibraryKit';
+import { fileIo as fs } from '@kit.CoreFileKit';
+import { image } from '@kit.ImageKit';
+import { hilog } from '@kit.PerformanceAnalysisKit';
+
+const TAG = 'PhotoPickerUtils';
+
+/**
+ * 通过系统图库选择器(PhotoViewPicker)选择图片
+ * @param maxSelectNumber 最大选择数量
+ * @returns 选中图片的URI数组，取消或失败返回空数组
+ */
+export async function selectPhotos(maxSelectNumber: number): Promise<string[]> {
+  try {
+    const photoSelectOptions = new photoAccessHelper.PhotoSelectOptions();
+    photoSelectOptions.MIMEType = photoAccessHelper.PhotoViewMIMETypes.IMAGE_TYPE;
+    photoSelectOptions.maxSelectNumber = maxSelectNumber;
+
+    const photoViewPicker = new photoAccessHelper.PhotoViewPicker();
+    const result: photoAccessHelper.PhotoSelectResult = await photoViewPicker.select(photoSelectOptions);
+
+    if (!result || !result.photoUris || result.photoUris.length === 0) {
+      return [];
+    }
+    return result.photoUris;
+  } catch (e) {
+    hilog.error(0x0000, TAG, 'selectPhotos error: ' + JSON.stringify(e));
+    return [];
+  }
+}
+
+/**
+ * 将源文件复制到目标目录，按时间戳+扩展名生成文件名
+ * @param srcUri 源文件URI
+ * @param destDir 目标目录路径（不带前缀file://）
+ * @returns 新文件的file://路径
+ */
+export async function copyFileToDir(srcUri: string, destDir: string): Promise<string> {
+  const srcFile = fs.openSync(srcUri, fs.OpenMode.READ_ONLY);
+  const timestamp = Date.now();
+  let fileName = '';
+  const srcPath = srcUri.toLowerCase();
+  if (srcPath.includes('.png')) {
+    fileName = `icon_${timestamp}.png`;
+  } else if (srcPath.includes('.jpg') || srcPath.includes('.jpeg')) {
+    fileName = `icon_${timestamp}.jpg`;
+  } else if (srcPath.includes('.svg')) {
+    fileName = `icon_${timestamp}.svg`;
+  } else if (srcPath.includes('.webp')) {
+    fileName = `icon_${timestamp}.webp`;
+  } else if (srcPath.includes('.bmp')) {
+    fileName = `icon_${timestamp}.bmp`;
+  } else if (srcPath.includes('.gif')) {
+    fileName = `icon_${timestamp}.gif`;
+  } else {
+    fileName = `icon_${timestamp}.png`;
+  }
+
+  const destPath = destDir + '/' + fileName;
+  fs.copyFileSync(srcFile.fd, destPath);
+  fs.closeSync(srcFile.fd);
+  return 'file://' + destPath;
+}
+
+/**
+ * 图片尺寸信息
+ */
+interface ImageDimensions {
+  width: number;
+  height: number;
+}
+
+/**
+ * 获取图片的宽高尺寸
+ * 通过 fileIo.openSync 打开文件 -> image.createImageSource(fd) -> getImageInfo() 获取 ImageInfo.size
+ * @param uri 图片文件URI
+ * @returns 图片尺寸，非图片或读取失败返回null
+ */
+export async function getImageDimensions(uri: string): Promise<ImageDimensions | null> {
+  try {
+    const file = fs.openSync(uri, fs.OpenMode.READ_ONLY);
+    const imageSource: image.ImageSource = image.createImageSource(file.fd);
+    const imageInfo: image.ImageInfo = await imageSource.getImageInfo();
+    const result: ImageDimensions = { width: imageInfo.size.width, height: imageInfo.size.height };
+    await imageSource.release();
+    fs.closeSync(file);
+    return result;
+  } catch (e) {
+    hilog.error(0x0000, TAG, 'getImageDimensions error: ' + JSON.stringify(e));
+    return null;
+  }
+}
+
+/**
+ * 将 PixelMap 打包为 PNG 并保存到目标目录
+ * 通过 ImagePacker.packToData() 将 PixelMap 编码为 PNG ArrayBuffer，再写入文件
+ * @param pm 要保存的 PixelMap（通常是裁剪后的结果）
+ * @param destDir 目标目录路径
+ * @returns 新文件的file://路径
+ */
+export async function savePixelMapToFile(pm: PixelMap, destDir: string): Promise<string> {
+  const imagePackerApi = image.createImagePacker();
+  const packOpts: image.PackingOption = { format: 'image/png', quality: 100 };
+  const buffer: ArrayBuffer = await imagePackerApi.packToData(pm, packOpts);
+  await imagePackerApi.release();
+
+  const timestamp = Date.now();
+  const fileName = `icon_${timestamp}.png`;
+  const destPath = destDir + '/' + fileName;
+
+  const file = fs.openSync(destPath, fs.OpenMode.CREATE | fs.OpenMode.WRITE_ONLY | fs.OpenMode.TRUNC);
+  fs.writeSync(file.fd, buffer);
+  fs.closeSync(file.fd);
+
+  return 'file://' + destPath;
+}

--- a/entry/src/main/ets/utils/TokenUtils.ets
+++ b/entry/src/main/ets/utils/TokenUtils.ets
@@ -315,6 +315,18 @@ export class UserAddedIconPack {
     fs.copyFileSync(file.fd, this.user_icon_path + "/" + file.name);
   }
 
+  /**
+   * 通过路径添加已复制的图标（用于裁剪后的图标和直接复制的小图标）
+   * 与 addIcon(fileIo.File) 不同，此方法跳过文件复制，直接注册路径
+   * @param iconPath 已存在于用户图标目录的文件路径（file://前缀）
+   */
+  public addIconByPath(iconPath: string): void {
+    this.latest_icon_path = iconPath;
+    if (this.icon_path.findIndex(_ => _ === iconPath) < 0) {
+      this.icon_path.push(iconPath);
+    }
+  }
+
   public removeIcon(path: string): void {
     this.icon_path = this.icon_path.filter(_ => _ !== path);
     fs.unlink(path.slice(7));

--- a/entry/src/main/ets/utils/TokenUtils.ets
+++ b/entry/src/main/ets/utils/TokenUtils.ets
@@ -296,6 +296,17 @@ export class UserAddedIconPack {
   public user_icon_path: string = '';
   public icon_path: string[] = [];
   public latest_icon_path: string = '';
+  /**
+   * 记录需要圆角显示的位图图标路径（裁剪后的PNG、直接复制的小位图等）
+   * SVG 矢量图标不加入此集合，因为它们有自身形状不适合强制圆角
+   * UI 层通过此集合判断是否添加 borderRadius
+   */
+  public raster_icons: Set<string> = new Set();
+
+  private isRasterFile(path: string): boolean {
+    const lower = path.toLowerCase();
+    return !lower.endsWith('.svg');
+  }
 
   public initIconPack(path: string): void {
     this.user_icon_path = path;
@@ -304,7 +315,11 @@ export class UserAddedIconPack {
     }
     fs.listFile(path).then((files) => {
       files.forEach((file) => {
-        this.icon_path.push("file://" + this.user_icon_path + "/" + file);
+        const fullPath = "file://" + this.user_icon_path + "/" + file;
+        this.icon_path.push(fullPath);
+        if (this.isRasterFile(file)) {
+          this.raster_icons.add(fullPath);
+        }
       })
     });
   }
@@ -312,6 +327,9 @@ export class UserAddedIconPack {
   public addIcon(file: fileIo.File): void {
     this.latest_icon_path = "file://" + this.user_icon_path + "/" + file.name;
     this.icon_path.push(this.latest_icon_path);
+    if (this.isRasterFile(file.name)) {
+      this.raster_icons.add(this.latest_icon_path);
+    }
     fs.copyFileSync(file.fd, this.user_icon_path + "/" + file.name);
   }
 
@@ -325,10 +343,14 @@ export class UserAddedIconPack {
     if (this.icon_path.findIndex(_ => _ === iconPath) < 0) {
       this.icon_path.push(iconPath);
     }
+    if (this.isRasterFile(iconPath)) {
+      this.raster_icons.add(iconPath);
+    }
   }
 
   public removeIcon(path: string): void {
     this.icon_path = this.icon_path.filter(_ => _ !== path);
+    this.raster_icons.delete(path);
     fs.unlink(path.slice(7));
   }
 


### PR DESCRIPTION
新增功能：

新增 ImageCropView 组件（参考 PersonalInfoUpload 项目），包含 CropModel（裁剪模型）和 CropView（圆形取景框 + 拖动/缩放手势），支持用户交互式裁剪图片
新增 PhotoPickerUtils 工具类，提供图片选择（selectPhotos）、文件复制（copyFileToDir）、图片尺寸获取（getImageDimensions，基于 image.createImageSource + getImageInfo）和 PixelMap 保存为文件（savePixelMapToFile，基于 ImagePacker.packToData）功能
自定义图标添加流程改进：

用户点击添加按钮后，通过 DocumentViewPicker 选择图片文件（支持 png/jpg/jpeg/svg/webp）
不使用photoAccessHelper.PhotoViewPicker 唤起系统图库选择器是因为经过测试系统图库选择器不支持svg
SVG 文件直接使用，跳过尺寸检查和裁剪
其他格式通过 getImageDimensions() 获取尺寸：小于等于258×258 直接复制使用，大于通过 bindContentCover 弹出全屏裁剪界面
裁剪后通过 ImagePacker 将 PixelMap 打包为 PNG 保存到用户图标目录
UI 圆角效果：

TokenIcon 和 ArcTokenIcon 组件的 Image 添加 .borderRadius(20)，所有图标（包括自定义图标）统一圆角显示
圆角效果在 UI 层实现，裁剪输出仍为矩形图片

Fixes #80
Closes #80 

<img width="459" height="926" alt="786cf88e-ea5f-4281-86d3-5896646223bc" src="https://github.com/user-attachments/assets/26ca6b0a-b18b-4881-890d-9b501fffc78d" />
<img width="496" height="1073" alt="6fa26261-7395-40a7-99b5-330e9e9b4ed6" src="https://github.com/user-attachments/assets/e7e19e11-de09-45f9-8a63-46a8e19093bd" />
