### PR TITLE
fix: 修复tabs页签点击切换没动画

### DIFF
--- a/entry/src/main/ets/pages/Index.ets
+++ b/entry/src/main/ets/pages/Index.ets
@@ -962,6 +962,7 @@ struct Index {
         .vertical(false)
         .barHeight(50 + this.window.AvoidBottomHeight)
         .barMode(BarMode.Fixed)
+        .animationDuration(300)
         .onChange((index) => {
           this.tab_bar_index = index;
         })


### PR DESCRIPTION
参考[HdsTabs](https://developer.huawei.com/consumer/cn/doc/harmonyos-references/ui-design-hdstabs#section13511122142)默认动画300ms

Closes #119 