### PR TITLE
ui: 适配API23沉浸光感页签和顶部菜单栏

### DIFF
--- a/entry/src/main/ets/components/SubItemEnumSelect.ets
+++ b/entry/src/main/ets/components/SubItemEnumSelect.ets
@@ -39,20 +39,42 @@ export struct SubItemEnumSelect {
 
   build() {
     Column() {
-      Row({ space: 10 }) {
-        if (this.icon != undefined) {
-          SymbolGlyph(this.icon)
-            .fontSize(20)
-            .fontWeight(FontWeight.Medium)
-            .fontColor([$r('app.color.str_main')])
-        }
-        Text(this.title)
-          .fontSize($r('sys.float.ohos_id_text_size_body1'))
-          .fontColor($r('sys.color.ohos_id_color_text_primary'))
-          .fontWeight(FontWeight.Regular)
-          .textAlign(TextAlign.Start)
+      Row({ space: 12 }) {
+        Column({ space: 4 }) {
+          Row({ space: 10 }) {
+            if (this.icon != undefined) {
+              SymbolGlyph(this.icon)
+                .fontSize(20)
+                .fontWeight(FontWeight.Medium)
+                .fontColor([$r('app.color.str_main')])
+            }
 
-        Blank()
+            Text(this.title)
+              .fontSize($r('sys.float.ohos_id_text_size_body1'))
+              .fontColor($r('sys.color.ohos_id_color_text_primary'))
+              .fontWeight(FontWeight.Regular)
+              .textAlign(TextAlign.Start)
+              .maxLines(1)
+              .textOverflow({ overflow: TextOverflow.Ellipsis })
+              .layoutWeight(1)
+          }
+          .width('100%')
+          .alignItems(VerticalAlign.Center)
+
+          if (this.description != '') {
+            Text(this.description)
+              .fontSize($r('sys.float.ohos_id_text_size_body2'))
+              .fontColor($r('sys.color.ohos_id_color_text_secondary'))
+              .fontWeight(FontWeight.Regular)
+              .fontFamily('HarmonyHeiTi')
+              .lineHeight(19)
+              .textAlign(TextAlign.Start)
+              .maxLines(2)
+              .textOverflow({ overflow: TextOverflow.Ellipsis })
+          }
+        }
+        .layoutWeight(1)
+        .alignItems(HorizontalAlign.Start)
 
         Select(this.options.map((option: EnumSelectOption) => {
           return { value: option.label as string } as SelectOption;
@@ -68,15 +90,7 @@ export struct SubItemEnumSelect {
           })
       }
       .width('100%')
-      if (this.description != '') {
-        Text(this.description)
-          .fontSize($r('sys.float.ohos_id_text_size_body2'))
-          .fontColor($r('sys.color.ohos_id_color_text_secondary'))
-          .fontWeight(FontWeight.Regular)
-          .fontFamily('HarmonyHeiTi')
-          .lineHeight(19)
-          .width('100%')
-      }
+      .alignItems(VerticalAlign.Center)
     }
     .padding(10)
   }

--- a/entry/src/main/ets/pages/Index.ets
+++ b/entry/src/main/ets/pages/Index.ets
@@ -42,7 +42,8 @@ import { HdsNavigation, HdsNavigationTitleMode, HdsTabs,
   ScrollEffectType, HdsListItemCard,
   PrefixIcon,
   IconSize,
-  SuffixArrow} from '@kit.UIDesignKit';
+  SuffixArrow,
+  hdsMaterial} from '@kit.UIDesignKit';
 import { ArcTokenListPage } from './ArcTokenListPage';
 import { LengthMetrics } from '@kit.ArkUI';
 import { testProtobufToJson } from '../utils/GoogleAuthUtils';
@@ -782,6 +783,10 @@ struct Index {
           scrollEffectOpts: {
             enableScrollEffect: true,
             scrollEffectType: this.currentScrollEffectType,
+          },
+          systemMaterialEffect: {
+            materialType: hdsMaterial.MaterialType.ADAPTIVE,
+            materialLevel: hdsMaterial.MaterialLevel.ADAPTIVE
           }
         },
         content: {
@@ -833,6 +838,10 @@ struct Index {
           scrollEffectOpts: {
             enableScrollEffect: true,
             scrollEffectType: this.currentScrollEffectType // 渐变模糊
+          },
+          systemMaterialEffect: {
+            materialType: hdsMaterial.MaterialType.ADAPTIVE,
+            materialLevel: hdsMaterial.MaterialLevel.ADAPTIVE
           }
         },
         content: {
@@ -881,6 +890,10 @@ struct Index {
                 scrollEffectOpts: {
                   enableScrollEffect: true,
                   scrollEffectType: this.currentScrollEffectType // 渐变模糊
+                },
+                systemMaterialEffect: {
+                  materialType: hdsMaterial.MaterialType.ADAPTIVE,
+                  materialLevel: hdsMaterial.MaterialLevel.ADAPTIVE
                 }
               },
               content: {
@@ -911,8 +924,7 @@ struct Index {
               selected: new SymbolGlyphModifier($r('sys.symbol.key_fill'))
             },
             $r('app.string.tab_token'))
-            .verticalAlign(VerticalAlign.Top)
-            .padding({top: LengthMetrics.vp(10)})
+            .verticalAlign(VerticalAlign.Center)
           )
           .tabIndex(0)
 
@@ -928,6 +940,10 @@ struct Index {
                 scrollEffectOpts: {
                   enableScrollEffect: true,
                   scrollEffectType: this.currentScrollEffectType // 实时模糊，渐变是GRADIENT_BLUR
+                },
+                systemMaterialEffect: {
+                  materialType: hdsMaterial.MaterialType.ADAPTIVE,
+                  materialLevel: hdsMaterial.MaterialLevel.ADAPTIVE
                 }
               },
               content: {
@@ -947,8 +963,7 @@ struct Index {
               selected: new SymbolGlyphModifier($r('sys.symbol.person_crop_circle_fill_1')),
             },
             $r('app.string.tab_me'))
-            .verticalAlign(VerticalAlign.Top)
-            .padding({top:  LengthMetrics.vp(10)})
+            .verticalAlign(VerticalAlign.Center)
           )
           .tabIndex(1)
         }
@@ -959,8 +974,14 @@ struct Index {
         .barBackgroundColor(Color.Transparent)
         .barBackgroundBlurStyle(BlurStyle.Regular)
         .barPosition(BarPosition.End)
+        .barFloatingStyle({
+          barBottomMargin: 28,
+          systemMaterialEffect: {
+            materialType: hdsMaterial.MaterialType.ADAPTIVE,
+            materialLevel: hdsMaterial.MaterialLevel.ADAPTIVE
+          }
+        })
         .vertical(false)
-        .barHeight(50 + this.window.AvoidBottomHeight)
         .barMode(BarMode.Fixed)
         .animationDuration(300)
         .onChange((index) => {

--- a/entry/src/main/ets/pages/Index.ets
+++ b/entry/src/main/ets/pages/Index.ets
@@ -8,7 +8,7 @@ import { DataSyncSheet } from '../pages/setting/DataSyncSheet'
 import { AgreementSheet } from '../pages/setting/AgreementSheet'
 import { AboutSheet } from '../pages/setting/AboutSheet'
 import { FeedbackSheet } from '../pages/setting/FeedbackSheet'
-import { util } from '@kit.ArkTS';
+import { util, url } from '@kit.ArkTS';
 import { fileIo as fs } from '@kit.CoreFileKit';
 import { BusinessError, systemDateTime } from '@kit.BasicServicesKit';
 import { showSnackBar, SnackBarNotifyType } from '../utils/HdsSnackBarUtils';
@@ -37,7 +37,7 @@ import { AgreementPage } from './AgreementPage';
 import { FeedbackPage } from './FeedbackPage';
 import { AppWindowInfo } from '../entryability/EntryAbility';
 import { AppLockOverlay } from './AppLockOverlay';
-import { AppStorageV2, SymbolGlyphModifier, window } from '@kit.ArkUI';
+import { AppStorageV2, ComponentContent, SymbolGlyphModifier, window } from '@kit.ArkUI';
 import { HdsNavigation, HdsNavigationTitleMode, HdsTabs,
   ScrollEffectType, HdsListItemCard,
   PrefixIcon,
@@ -46,11 +46,47 @@ import { HdsNavigation, HdsNavigationTitleMode, HdsTabs,
   hdsMaterial} from '@kit.UIDesignKit';
 import { ArcTokenListPage } from './ArcTokenListPage';
 import { LengthMetrics } from '@kit.ArkUI';
-import { testProtobufToJson } from '../utils/GoogleAuthUtils';
+import { decodeProtobuf } from '../utils/GoogleAuthUtils';
+import { TOTPConfigDialog } from '../dialogs/OTPConfigDialog';
+import { URIConfigDialog } from '../dialogs/URIConfigDialog';
+import { FortiConfigDialog } from '../dialogs/FortiConfigDialog';
+import { SteamConfigDialog } from '../dialogs/SteamConfigDialog';
+import { ScanBarCode } from '../utils/TokenUtils';
 
 const TAG = 'PrivacySubscribe';
 
 let tkStore = TokenStore.getInstance();
+
+@Builder
+function TokenAddMenuBuilder(host: Index) {
+  Menu() {
+    MenuItem({ content: $r('app.string.app_scan_code') })
+      .onClick(() => {
+        host.start_quick_scan();
+      })
+      .accessibilityText($r('app.string.app_scan_code'))
+    MenuItem({ content: $r('app.string.tab_token_add_key') })
+      .onClick(() => {
+        host.openTotpAddDialog();
+      })
+      .accessibilityText($r('app.string.tab_token_add_key'))
+    MenuItem({ content: $r('app.string.tab_token_add_uri') })
+      .onClick(() => {
+        host.openUriAddDialog();
+      })
+      .accessibilityText($r('app.string.tab_token_add_uri'))
+    MenuItem({ content: $r('app.string.tab_token_add_forti_key') })
+      .onClick(() => {
+        host.openFortiAddDialog();
+      })
+      .accessibilityText($r('app.string.tab_token_add_forti_key'))
+    MenuItem({ content: $r('app.string.tab_token_add_stream_key') })
+      .onClick(() => {
+        host.openSteamAddDialog();
+      })
+      .accessibilityText($r('app.string.tab_token_add_stream_key'))
+  }
+}
 
 @Entry
 @ComponentV2
@@ -137,6 +173,11 @@ struct Index {
   })
 
   private backup_select_uri: string = '';
+  private readonly addTokenMenuTargetId: string = 'app_ua_add_token';
+  private dialog_uri_config?: CustomDialogController;
+  private dialog_totp_config?: CustomDialogController;
+  private dialog_forti_config?: CustomDialogController;
+  private dialog_steam_config?: CustomDialogController;
 
   aboutToAppear(): void {
     PermissionManager.getInstance().verifyPermissionsAndPushEvent();
@@ -209,6 +250,10 @@ struct Index {
         AppPreference.setPreference(PREF_KEYS.DB_RDS_CLOUD_SYNC_ENABLE, false);
       }
     })
+
+    if (this.appCtx.eventHub != undefined) this.appCtx.eventHub.on(EVENT_NAMES.START_QUICK_SCAN, () => {
+      this.start_quick_scan();
+    });
 
     if (this.appCtx.eventHub!= undefined) this.appCtx.eventHub.on(EVENT_NAMES.FILE_DROP, (uri: string) => {
       this.backup_select_uri = uri;
@@ -389,6 +434,83 @@ struct Index {
       await this.updateTokenConfig(tokens[i], false);
     }
     showSnackBar($r('app.string.toast_multi_token_update', tokens.length), SnackBarNotifyType.SUCCESS);
+  }
+
+  private openAddTokenMenu(): void {
+    const uiContext = this.getUIContext();
+    const promptAction = uiContext.getPromptAction();
+    const contentNode = new ComponentContent(uiContext, wrapBuilder(TokenAddMenuBuilder), this);
+    try {
+      promptAction.openMenu(contentNode, { id: this.addTokenMenuTargetId }, {});
+    } catch (error) {
+      const err = error as BusinessError;
+      hilog.error(err.code, 'Index', `openAddTokenMenu failed: ${err.message}`);
+    }
+  }
+
+  start_quick_scan() {
+    ScanBarCode().then((code) => {
+      if (code.startsWith('otpauth-migration://offline?data=')) {
+        const data = new url.URLParams(url.URL.parseURL(code).search).get('data');
+        decodeProtobuf(decodeURIComponent(data ?? '')).then((confs) => {
+          this.updateTokenConfigs(confs);
+        });
+      } else if (code.startsWith('otpauth://')) {
+        this.dialog_totp_config = new CustomDialogController({
+          builder: TOTPConfigDialog({
+            scan_code_original_Value: code,
+            confirm: (new_conf) => {
+              this.updateTokenConfig(JSON.parse(new_conf), true)
+            }
+          })
+        })
+        this.dialog_totp_config.open()
+      }
+    });
+  }
+
+  openTotpAddDialog(): void {
+    this.dialog_totp_config = new CustomDialogController({
+      builder: TOTPConfigDialog({
+        confirm: (new_conf) => {
+          this.updateTokenConfig(JSON.parse(new_conf), true)
+        }
+      })
+    })
+    this.dialog_totp_config.open()
+  }
+
+  openUriAddDialog(): void {
+    this.dialog_uri_config = new CustomDialogController({
+      builder: URIConfigDialog({
+        confirm: (tokens) => {
+          this.updateTokenConfigs(tokens);
+        }
+      })
+    })
+    this.dialog_uri_config.open()
+  }
+
+  openFortiAddDialog(): void {
+    this.dialog_forti_config = new CustomDialogController({
+      builder: FortiConfigDialog({
+        confirm: (new_conf) => {
+          this.updateTokenConfig(JSON.parse(new_conf), true)
+        }
+      })
+    })
+    this.dialog_forti_config.open()
+  }
+
+  openSteamAddDialog(): void {
+    this.dialog_steam_config = new CustomDialogController({
+      builder: SteamConfigDialog({
+        confirm: (new_conf) => {
+          this.updateTokenConfig(JSON.parse(new_conf), true)
+        }
+      })
+    })
+    this.dialog_steam_config.open()
   }
 
   // 准备接入标准化隐私托管
@@ -859,6 +981,17 @@ struct Index {
                     if (this.appCtx.eventHub != undefined) this.appCtx.eventHub.emit(EVENT_NAMES.TOGGLE_TOKEN_SEARCH);
                   }
                 }
+              },
+              {
+                content: {
+                  label: $r('app.string.app_ua_add_token'),
+                  icon: $r('sys.symbol.plus'),
+                  isEnabled: true,
+                  componentId: this.addTokenMenuTargetId,
+                  action: () => {
+                    this.openAddTokenMenu();
+                  }
+                }
               }
             ]
           }
@@ -909,6 +1042,17 @@ struct Index {
                         isEnabled: true,
                         action: () => {
                           if (this.appCtx.eventHub != undefined) this.appCtx.eventHub.emit(EVENT_NAMES.TOGGLE_TOKEN_SEARCH);
+                        }
+                      }
+                    },
+                    {
+                      content: {
+                        label: $r('app.string.app_ua_add_token'),
+                        icon: $r('sys.symbol.plus'),
+                        isEnabled: true,
+                        componentId: this.addTokenMenuTargetId,
+                        action: () => {
+                          this.openAddTokenMenu();
                         }
                       }
                     }

--- a/entry/src/main/ets/pages/TokenListPage.ets
+++ b/entry/src/main/ets/pages/TokenListPage.ets
@@ -6,25 +6,11 @@ import { SteamConfigDialog } from "../dialogs/SteamConfigDialog";
 import { AppPreference, SettingValue, TokenPreference, EVENT_NAMES, PREF_KEYS } from "../utils/AppPreference";
 import { otpType, TokenConfig } from "../utils/TokenConfig";
 import { TokenStore } from "../utils/TokenStore";
-import { convertToken2URI, ScanBarCode } from "../utils/TokenUtils";
-import { AppStorageV2, ComponentContent, curves, window } from "@kit.ArkUI";
-import { ActionBarButton, ActionBarStyle, HdsActionBar } from "@kit.UIDesignKit";
-import { url } from "@kit.ArkTS";
-import { abilityAccessCtrl, bundleManager, common, Permissions } from "@kit.AbilityKit";
-import { BusinessError } from "@kit.BasicServicesKit";
-import { hilog } from '@kit.PerformanceAnalysisKit';
-import { motion } from "@kit.MultimodalAwarenessKit";
-import { decodeProtobuf } from "../utils/GoogleAuthUtils";
-import { URIConfigDialog } from "../dialogs/URIConfigDialog";
+import { convertToken2URI } from "../utils/TokenUtils";
+import { AppStorageV2, curves, window } from "@kit.ArkUI";
 import { AppWindowInfo } from "../entryability/EntryAbility";
 
 let tkStore = TokenStore.getInstance();
-
-enum HoldingHandLayoutMode {
-  LEFT = 'left',
-  CENTER = 'center',
-  RIGHT = 'right'
-}
 
 @Preview
 @ComponentV2
@@ -40,7 +26,6 @@ export struct TokenListPage {
 
   @Local token_preference: TokenPreference = AppStorageV2.connect(TokenPreference) as TokenPreference;
   @Local window: AppWindowInfo = AppStorageV2.connect(AppWindowInfo) as AppWindowInfo;
-  @Local appCtx: common.UIAbilityContext = AppStorage.get('appContext') as common.UIAbilityContext;
 
   @Local token_copy_guide_popup: boolean = false;
 
@@ -50,23 +35,10 @@ export struct TokenListPage {
   @Local token_list_search_str: string = '';
   @Local id_list: string[] = ['search_bar', 'search_blur_anchor'];
 
-  @Local isExpand: boolean = false;
-  @Local isPrimaryIconChanged: boolean = false;
-  @Local primaryHoverTips: string = '收起';
-  @Local isTokenAddMenuShown: boolean = false;
-  @Local actionBarOffsetX: number = 0;
-  @Local holdingHandLayoutMode: HoldingHandLayoutMode = HoldingHandLayoutMode.CENTER;
-
-  private dialog_uri_config?: CustomDialogController;
   private dialog_totp_config?: CustomDialogController;
   private dialog_forti_config?: CustomDialogController;
   private dialog_steam_config?: CustomDialogController;
   private dialog_qrcode?: CustomDialogController;
-  private readonly holdingHandPermission: Permissions = 'ohos.permission.DETECT_GESTURE';
-  private readonly actionBarMoveRatio: number = 0.22;
-  private readonly actionBarMoveMaxOffset: number = 80;
-  private holdingHandSubscribed: boolean = false;
-  private holdingHandCallback?: Callback<motion.HoldingHandStatus>;
 
   async filterCurrentTokens(filter_word: string): Promise<void> {
     if (filter_word.length === 0) {
@@ -85,16 +57,7 @@ export struct TokenListPage {
     if (AppPreference.getPreference(PREF_KEYS.SHOW_GUIDE_TIPS) as boolean) {
       this.token_copy_guide_popup = true;
     }
-    getContext(this).eventHub.on(EVENT_NAMES.START_QUICK_SCAN, () => { this.start_quick_scan() });
     getContext(this).eventHub.on(EVENT_NAMES.TOGGLE_TOKEN_SEARCH, () => { this.toggleTokenSearchByTitleBar() });
-    getContext(this).eventHub.on(EVENT_NAMES.HOLDING_HAND_PREFERENCE_CHANGED, (enabled: boolean) => {
-      this.handleHoldingHandPreferenceChanged(enabled);
-    });
-    this.handleHoldingHandPreferenceChanged(this.token_preference.app_appearance_holding_hand_enable);
-  }
-
-  aboutToDisappear(): void {
-    this.unsubscribeHoldingHandAwareness();
   }
 
   private toggleTokenSearchByTitleBar(): void {
@@ -114,131 +77,6 @@ export struct TokenListPage {
       setTimeout(() => {
         focusControl.requestFocus(this.id_list[1])
       }, 100)
-    }
-  }
-
-  private async initHoldingHandAwareness(): Promise<void> {
-    this.holdingHandCallback = (status: motion.HoldingHandStatus) => {
-      this.applyHoldingHandLayout(this.mapHoldingHandStatusToLayout(status));
-    };
-    const hasPermission = await this.ensureHoldingHandPermission();
-    if (!hasPermission) {
-      this.applyHoldingHandLayout(HoldingHandLayoutMode.CENTER);
-      return;
-    }
-    this.subscribeHoldingHandAwareness();
-  }
-
-  private handleHoldingHandPreferenceChanged(enabled: boolean): void {
-    if (!enabled) {
-      this.unsubscribeHoldingHandAwareness();
-      this.applyHoldingHandLayout(HoldingHandLayoutMode.CENTER);
-      return;
-    }
-    this.initHoldingHandAwareness();
-  }
-
-  private async ensureHoldingHandPermission(): Promise<boolean> {
-    const granted = await this.checkPermissionGranted(this.holdingHandPermission);
-    if (granted) {
-      return true;
-    }
-    if (!this.appCtx) {
-      return false;
-    }
-    try {
-      const requestResult = await abilityAccessCtrl.createAtManager()
-        .requestPermissionsFromUser(this.appCtx, [this.holdingHandPermission]);
-      return requestResult.authResults.every((status) => status === 0);
-    } catch (error) {
-      const err = error as BusinessError;
-      hilog.error(err.code, 'TokenListPage', `Failed to request holding hand permission. Code: ${err.code}, message: ${err.message}`);
-      return false;
-    }
-  }
-
-  private async checkPermissionGranted(permission: Permissions): Promise<boolean> {
-    try {
-      const bundleInfo = await bundleManager.getBundleInfoForSelf(bundleManager.BundleFlag.GET_BUNDLE_INFO_WITH_APPLICATION);
-      const grantStatus = await abilityAccessCtrl.createAtManager().checkAccessToken(bundleInfo.appInfo.accessTokenId, permission);
-      return grantStatus === abilityAccessCtrl.GrantStatus.PERMISSION_GRANTED;
-    } catch (error) {
-      const err = error as BusinessError;
-      hilog.error(err.code, 'TokenListPage', `Failed to check holding hand permission. Code: ${err.code}, message: ${err.message}`);
-      return false;
-    }
-  }
-
-  private subscribeHoldingHandAwareness(): void {
-    if (this.holdingHandSubscribed || !this.holdingHandCallback) {
-      return;
-    }
-    try {
-      motion.on('holdingHandChanged', this.holdingHandCallback);
-      this.holdingHandSubscribed = true;
-    } catch (error) {
-      const err = error as BusinessError;
-      if (err.code === 801 || err.code === 201) {
-        this.applyHoldingHandLayout(HoldingHandLayoutMode.CENTER);
-      }
-      hilog.error(err.code, 'TokenListPage', `Failed to subscribe holding hand awareness. Code: ${err.code}, message: ${err.message}`);
-    }
-  }
-
-  private unsubscribeHoldingHandAwareness(): void {
-    if (!this.holdingHandSubscribed) {
-      return;
-    }
-    try {
-      if (this.holdingHandCallback) {
-        motion.off('holdingHandChanged', this.holdingHandCallback);
-      } else {
-        motion.off('holdingHandChanged');
-      }
-    } catch (error) {
-      const err = error as BusinessError;
-      hilog.error(err.code, 'TokenListPage', `Failed to unsubscribe holding hand awareness. Code: ${err.code}, message: ${err.message}`);
-    } finally {
-      this.holdingHandSubscribed = false;
-    }
-  }
-
-  private mapHoldingHandStatusToLayout(status: motion.HoldingHandStatus): HoldingHandLayoutMode {
-    switch (status) {
-      case motion.HoldingHandStatus.LEFT_HAND_HELD:
-        return HoldingHandLayoutMode.LEFT;
-      case motion.HoldingHandStatus.RIGHT_HAND_HELD:
-        return HoldingHandLayoutMode.RIGHT;
-      case motion.HoldingHandStatus.BOTH_HANDS_HELD:
-      case motion.HoldingHandStatus.NOT_HELD:
-      case motion.HoldingHandStatus.UNKNOWN_STATUS:
-      default:
-        return HoldingHandLayoutMode.CENTER;
-    }
-  }
-
-  private applyHoldingHandLayout(mode: HoldingHandLayoutMode): void {
-    const nextOffset = this.getActionBarOffsetByMode(mode);
-    if (this.holdingHandLayoutMode === mode && this.actionBarOffsetX === nextOffset) {
-      return;
-    }
-    this.window.uiContext?.animateTo({ duration: 300, curve: curves.springMotion() }, () => {
-      this.holdingHandLayoutMode = mode;
-      this.actionBarOffsetX = nextOffset;
-    })
-  }
-
-  private getActionBarOffsetByMode(mode: HoldingHandLayoutMode): number {
-    const width = Number(this.appWindowSize.width ?? 0);
-    const baseOffset = Math.min(width * this.actionBarMoveRatio, this.actionBarMoveMaxOffset);
-    switch (mode) {
-      case HoldingHandLayoutMode.LEFT:
-        return -baseOffset;
-      case HoldingHandLayoutMode.RIGHT:
-        return baseOffset;
-      case HoldingHandLayoutMode.CENTER:
-      default:
-        return 0;
     }
   }
 
@@ -367,7 +205,7 @@ export struct TokenListPage {
 
           ListItem() {
             Row()
-              .height(this.TabBarVisible ? (120 + this.appBottomAvoidHeight) : (20 + this.appBottomAvoidHeight))
+              .height(this.TabBarVisible ? (60 + this.appBottomAvoidHeight) : (20 + this.appBottomAvoidHeight))
               .width('100%')
           }
           .selectable(false)
@@ -380,54 +218,6 @@ export struct TokenListPage {
         .chainAnimation(true)
         .scrollBar(BarState.Off)
         .edgeEffect(EdgeEffect.Spring, { alwaysEnabled: true })
-      }
-      if (this.TabBarVisible) {
-        Row() {
-          HdsActionBar({
-            startButtons: [new ActionBarButton({
-              baseIcon: $r('sys.symbol.plus'),
-              hoverTips: $r('app.string.app_ua_add_token'),
-              accessibilityText: $r('app.string.app_ua_add_token'),
-              onClick: () => {
-                this.isTokenAddMenuShown = true;
-              }
-            })],
-            endButtons: [new ActionBarButton({
-              baseIcon: $r('sys.symbol.line_viewfinder'),
-              hoverTips: $r('app.string.app_scan_code'),
-              accessibilityText: $r('app.string.app_scan_code'),
-              onClick: () => {
-                this.start_quick_scan();
-              }
-            })],
-            primaryButton: new ActionBarButton({
-              baseIcon: $r('sys.symbol.plus'),
-              altIcon: $r('sys.symbol.xmark'),
-              hoverTips: this.primaryHoverTips,
-              accessibilityText: this.primaryHoverTips,
-              onClick: () => {
-                this.isExpand = !this.isExpand;
-                this.isPrimaryIconChanged = !this.isPrimaryIconChanged;
-                this.primaryHoverTips = this.isExpand ? '收起' : '展开';
-              }
-            }),
-            actionBarStyle: new ActionBarStyle({
-              isPrimaryIconChanged: this.isPrimaryIconChanged,
-            }),
-            isExpand: this.isExpand
-          })
-            .translate({ x: this.actionBarOffsetX, y: 0 })
-            .bindMenu(this.isTokenAddMenuShown, this.TokenAddMenu, {
-              placement: Placement.BottomLeft,
-              onWillDisappear: () => {
-                this.isTokenAddMenuShown = false;
-              }
-            })
-        }
-        .width('100%')
-        .justifyContent(FlexAlign.Center)
-        .margin({ bottom: this.appBottomAvoidHeight + 35 })
-        .hitTestBehavior(HitTestMode.None)
       }
     }
   }
@@ -542,78 +332,5 @@ export struct TokenListPage {
       }
     }
     .margin({ left: 10 })
-  }
-
-  @Builder
-  TokenAddMenu() {
-    Menu() {
-      MenuItem({ content: $r('app.string.app_scan_code') })
-        .onClick(async () => {
-          this.start_quick_scan();
-        })
-        .accessibilityText($r('app.string.app_scan_code'))
-      MenuItem({ content: $r('app.string.tab_token_add_key') })
-        .onClick(() => {
-          this.dialog_totp_config = new CustomDialogController({
-            builder: TOTPConfigDialog({
-              confirm: (new_conf) => {this.updateTokenConfig(JSON.parse(new_conf), true)}
-            })
-          })
-          this.dialog_totp_config.open()
-        })
-        .accessibilityText($r('app.string.tab_token_add_key'))
-      MenuItem({ content: $r('app.string.tab_token_add_uri') })
-        .onClick(() => {
-          this.dialog_uri_config = new CustomDialogController({
-            builder: URIConfigDialog({
-              confirm: (tokens) => {
-                this.updateTokenConfigs(tokens);
-              }
-            })
-          })
-          this.dialog_uri_config.open()
-        })
-        .accessibilityText($r('app.string.tab_token_add_uri'))
-      MenuItem({ content: $r('app.string.tab_token_add_forti_key') })
-        .onClick(() => {
-          this.dialog_forti_config = new CustomDialogController({
-            builder: FortiConfigDialog({
-              confirm: (new_conf) => {this.updateTokenConfig(JSON.parse(new_conf), true)}
-            })
-          })
-          this.dialog_forti_config.open()
-        })
-        .accessibilityText($r('app.string.tab_token_add_forti_key'))
-      MenuItem({ content: $r('app.string.tab_token_add_stream_key') })
-        .onClick(() => {
-          this.dialog_steam_config = new CustomDialogController({
-            builder: SteamConfigDialog({
-              confirm: (new_conf) => {this.updateTokenConfig(JSON.parse(new_conf), true)}
-            })
-          })
-          this.dialog_steam_config.open()
-        })
-        .accessibilityText($r('app.string.tab_token_add_stream_key'))
-    }
-  }
-
-  start_quick_scan() {
-    ScanBarCode().then((code) => {
-      // google authenticator migration
-      if (code.startsWith('otpauth-migration://offline?data=')) {
-        const data = new url.URLParams(url.URL.parseURL(code).search).get("data");
-        decodeProtobuf(decodeURIComponent(data ?? '')).then((confs) => {
-          this.updateTokenConfigs(confs);
-        });
-      } else if (code.startsWith('otpauth://')) {
-        this.dialog_totp_config = new CustomDialogController({
-          builder: TOTPConfigDialog({
-            scan_code_original_Value: code, // 弹窗立刻扫码赋值
-            confirm: (new_conf) => {this.updateTokenConfig(JSON.parse(new_conf), true)}
-          })
-        })
-        this.dialog_totp_config.open()
-      }
-    });
   }
 }

--- a/entry/src/main/ets/pages/setting/AppearanceSheet.ets
+++ b/entry/src/main/ets/pages/setting/AppearanceSheet.ets
@@ -106,6 +106,23 @@ export struct AppearanceSheet {
 
             SubItemDivider()
 
+            SubItemEnumSelect({
+              icon: $r('sys.symbol.slider_horizontal_2'),
+              title: $r('app.string.setting_top_effect_type'),
+              options: AVAILABLE_TOP_EFFECT_TYPES,
+              description: $r('app.string.setting_top_effect_type_desc'),
+              selected: AppPreference.getPreference(PREF_KEYS.APPEARANCE_TOP_EFFECT_TYPE) as number ??
+                SettingTopEffectType.GRADUAL_BLUR,
+              onChange: (value: number) => {
+                AppPreference.setPreference(PREF_KEYS.APPEARANCE_TOP_EFFECT_TYPE, value);
+                if (this.appCtx.eventHub != undefined) {
+                  this.appCtx.eventHub.emit(EVENT_NAMES.TOP_EFFECT_TYPE_CHANGED);
+                }
+              }
+            })
+
+            SubItemDivider()
+
             SubItemIconManager()
 
             SubItemDivider()
@@ -117,36 +134,8 @@ export struct AppearanceSheet {
               .onClick(throttle((event) => {
                 this.pageInfos.pushPathByName(ROUTE_NAMES.AppearancePage, null);
               }, 1000))
-            SubItemDivider()
-
-            SubItemEnumSelect({
-              icon: $r('sys.symbol.slider_horizontal_2'),
-              title: $r('app.string.setting_top_effect_type'),
-              options: AVAILABLE_TOP_EFFECT_TYPES,
-              description: $r('app.string.setting_top_effect_type_desc'),
-              selected: AppPreference.getPreference(PREF_KEYS.APPEARANCE_TOP_EFFECT_TYPE) as number ??
-              SettingTopEffectType.GRADUAL_BLUR,
-              onChange: (value: number) => {
-                AppPreference.setPreference(PREF_KEYS.APPEARANCE_TOP_EFFECT_TYPE, value);
-                if (this.appCtx.eventHub != undefined) {
-                  this.appCtx.eventHub.emit(EVENT_NAMES.TOP_EFFECT_TYPE_CHANGED);
-                }
-              }
-            })
 
             SubItemDivider()
-
-            SubItemEnumSelect({
-              icon: $r('sys.symbol.slider_horizontal_2'),
-              title: $r('app.string.setting_bottom_tabs_type'),
-              options: AVAILABLE_BOTTOM_TABS_TYPES,
-              description: $r('app.string.setting_bottom_tabs_type_desc'),
-              selected: AppPreference.getPreference(PREF_KEYS.APPEARANCE_BOTTOM_TABS_TYPE) as number ??
-              SettingBottomTabsType.FLATTEN,
-              onChange: (value: number) => {
-                AppPreference.setPreference(PREF_KEYS.APPEARANCE_BOTTOM_TABS_TYPE, value);
-              }
-            })
           }
         }
         .padding({ left: 10, right: 10 })

--- a/entry/src/main/ets/utils/AppPreference.ets
+++ b/entry/src/main/ets/utils/AppPreference.ets
@@ -81,8 +81,6 @@ export enum PREF_KEYS {
   APPEARANCE_SHOW_NEXT_TOKEN_ENABLE = 'app_appearance_show_next_token_enable',
   /** 握手感知开关 */
   APPEARANCE_HOLDING_HAND_ENABLE = 'app_appearance_holding_hand_enable',
-  /** 底部Tabs类型 */
-  APPEARANCE_BOTTOM_TABS_TYPE = 'app_appearance_bottom_tabs_type',
   /** 显示引导提示开关 */
   SHOW_GUIDE_TIPS = 'app_show_guide_tips',
   /** Token项目高度 */
@@ -396,8 +394,6 @@ export class AppPreference {
     [PREF_KEYS.APPEARANCE_ITEM_MAX_WIDTH, 800],
     // 外观-顶部模糊类型
     [PREF_KEYS.APPEARANCE_TOP_EFFECT_TYPE, SettingTopEffectType.GRADIENT_BLUR],
-    // 外观-底部Tabs类型
-    [PREF_KEYS.APPEARANCE_BOTTOM_TABS_TYPE, SettingBottomTabsType.FLATTEN]
   ]);
 
   private static settings: Map<string, SettingValue> = new Map<string, SettingValue>([

--- a/entry/src/main/resources/base/element/string.json
+++ b/entry/src/main/resources/base/element/string.json
@@ -823,6 +823,58 @@
     {
       "name": "setting_feedback",
       "value": "Suggest & Feedback"
+    },
+    {
+      "name": "app_biometric_login",
+      "value": "Biometric Login"
+    },
+    {
+      "name": "dialog_icon_select_custom",
+      "value": "Custom"
+    },
+    {
+      "name": "setting_top_effect_type",
+      "value": "Title Bar Blur Type"
+    },
+    {
+      "name": "setting_top_effect_type_desc",
+      "value": "Control the type of title bar blur effect"
+    },
+    {
+      "name": "setting_top_effect_type_disable",
+      "value": "Disabled"
+    },
+    {
+      "name": "setting_top_effect_type_common_blur",
+      "value": "Common Blur"
+    },
+    {
+      "name": "setting_top_effect_type_gradual_blur",
+      "value": "Gradual Blur"
+    },
+    {
+      "name": "setting_top_effect_type_gradient_blur",
+      "value": "Gradient Blur"
+    },
+    {
+      "name": "setting_top_effect_type_immersive_gradient_blur",
+      "value": "Immersive Gradient Blur"
+    },
+    {
+      "name": "setting_bottom_tabs_type",
+      "value": "Bottom Tabs Type"
+    },
+    {
+      "name": "setting_bottom_tabs_type_desc",
+      "value": "Control the display type of bottom tab bar"
+    },
+    {
+      "name": "setting_bottom_tabs_type_flatten",
+      "value": "Flatten"
+    },
+    {
+      "name": "setting_bottom_tabs_type_suspension",
+      "value": "Suspension"
     }
   ]
 }

--- a/entry/src/main/resources/en_US/element/string.json
+++ b/entry/src/main/resources/en_US/element/string.json
@@ -822,11 +822,11 @@
     },
     {
       "name": "setting_top_effect_type",
-      "value": "Top Blur Type"
+      "value": "Title Bar Blur Type"
     },
     {
       "name": "setting_top_effect_type_desc",
-      "value": "Control the type of top blur effect"
+      "value": "Control the type of title bar blur effect"
     },
     {
       "name": "setting_top_effect_type_disable",

--- a/entry/src/main/resources/zh_CN/element/string.json
+++ b/entry/src/main/resources/zh_CN/element/string.json
@@ -826,7 +826,7 @@
     },
     {
       "name": "setting_top_effect_type_desc",
-      "value": "控制顶部模糊效果的类型"
+      "value": "控制顶部模糊效果的类型。"
     },
     {
       "name": "setting_top_effect_type_disable",

--- a/entry/src/main/resources/zh_TW/element/string.json
+++ b/entry/src/main/resources/zh_TW/element/string.json
@@ -826,7 +826,7 @@
     },
     {
       "name": "setting_top_effect_type_desc",
-      "value": "控制頂部模糊效果的類型"
+      "value": "控制頂部模糊效果的類型。"
     },
     {
       "name": "setting_top_effect_type_disable",


### PR DESCRIPTION
- 页签适配悬浮沉浸光感，默认`hdsMaterial.MaterialType.ADAPTIVE`，这块后期可以给选项强制沉浸式材质
- 移除`HdsActionBar`，添加令牌移动到顶部菜单栏，与搜索按钮适配沉浸光感视效
- 移除底部页签类型选项