### PR TITLE
优化华为云备份页面 备份任务迁移至后台线程

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 **/.test
 /.appanalyzer
 /.bitfun
+/.playwright-mcp/

--- a/AppScope/app.json5
+++ b/AppScope/app.json5
@@ -2,7 +2,7 @@
   "app": {
     "bundleName": "smartcityshenzhen.yylx.totptoken",
     "vendor": "opensource",
-    "versionCode": 1002031,
+    "versionCode": 1002032,
     "versionName": "1.2.3",
     "icon": "$media:app_icon",
     "label": "$string:app_name",

--- a/entry/src/main/ets/pages/Index.ets
+++ b/entry/src/main/ets/pages/Index.ets
@@ -498,7 +498,7 @@ struct Index {
               this.syncHuaweiAccountState();
               this.isAccountSheetVisible = false;
               AppPreference.setPreference(PREF_KEYS.APPEARANCE_HUAWEI_CLOUD_SYNC_ENABLE, false);
-              AppPreference.setPreference(PREF_KEYS.CLOUD_SYNC_LAST_TIME, '');
+              AppPreference.setPreference(PREF_KEYS.CLOUD_SYNC_LAST_TIME, '0');
             });
           }
         },
@@ -523,7 +523,7 @@ struct Index {
           HuaweiAccountManager.getInstance().logout().then(() => {
             this.syncHuaweiAccountState();
             AppPreference.setPreference(PREF_KEYS.APPEARANCE_HUAWEI_CLOUD_SYNC_ENABLE, false);
-            AppPreference.setPreference(PREF_KEYS.CLOUD_SYNC_LAST_TIME, '');
+            AppPreference.setPreference(PREF_KEYS.CLOUD_SYNC_LAST_TIME, '0');
           });
         }
       });

--- a/entry/src/main/ets/pages/ShowCloudBackupHistoryPage.ets
+++ b/entry/src/main/ets/pages/ShowCloudBackupHistoryPage.ets
@@ -7,6 +7,15 @@ import { showSnackBar, SnackBarNotifyType } from '../utils/HdsSnackBarUtils';
 import { hdsMaterial, HdsNavDestination, HdsNavDestinationTitleMode, ScrollEffectType } from '@kit.UIDesignKit';
 import { CommonConstants } from '../utils/CommonConstants';
 import { DeviceInfoHelper } from '../utils/DeviceInfoHelper';
+import { SyncTimeHelper } from '../utils/SyncTimeHelper';
+import { common } from '@kit.AbilityKit';
+import { BusinessError } from '@kit.BasicServicesKit';
+import { hilog } from '@kit.PerformanceAnalysisKit';
+import { taskpool } from '@kit.ArkTS';
+import { loadBackupHistoryRecords } from '../utils/CloudSyncTask';
+
+const TAG = 'ShowCloudBackupHistoryPage';
+const DOMAIN = 0xFF00;
 
 @Entry
 @Preview
@@ -18,26 +27,38 @@ export struct ShowCloudBackupHistoryPage {
   @Local isLoading: boolean = true;
   @Local currentDeviceId: string = '';
   @Local window: AppWindowInfo = AppStorageV2.connect(AppWindowInfo) as AppWindowInfo;
+  @Local appCtx: common.UIAbilityContext = AppStorage.get('appContext') as common.UIAbilityContext;
   private backupManager: CloudBackupManager = CloudBackupManager.getInstance();
   private scroller: Scroller = new Scroller();
 
+  /** 页面生命周期：获取本设备 ID，加载备份历史列表 */
   aboutToAppear(): void {
     this.currentDeviceId = DeviceInfoHelper.getInstance().getDeviceId();
     this.loadBackupHistory();
   }
 
+  /**
+   * 通过 TaskPool 后台线程加载备份历史记录，避免逐文件 I/O 阻塞主线程。
+   * 后台线程执行目录遍历 + 文件读取 + header 解析，完成后回主线程更新 UI。
+   */
   private loadBackupHistory(): void {
     this.isLoading = true;
-    this.backupManager.listBackupHistory().then((records: CloudBackupRecord[]) => {
-      this.backupRecords = records;
+    const cloudDir: string = this.appCtx.cloudFileDir;
+    taskpool.execute(loadBackupHistoryRecords, cloudDir).then((result: Object) => {
+      this.backupRecords = result as CloudBackupRecord[];
       this.isLoading = false;
+    }).catch((err: BusinessError) => {
+      this.isLoading = false;
+      hilog.error(DOMAIN, TAG, `loadBackupHistory: taskpool failed: ${err.code} ${err.message}`);
     });
   }
 
+  /** 筛选当前设备的备份记录 */
   private getDeviceRecords(): CloudBackupRecord[] {
     return this.backupRecords.filter(r => r.deviceId === this.currentDeviceId);
   }
 
+  /** 筛选其他设备的备份记录 */
   private getOtherDeviceRecords(): CloudBackupRecord[] {
     return this.backupRecords.filter(r => r.deviceId !== this.currentDeviceId);
   }
@@ -55,7 +76,6 @@ export struct ShowCloudBackupHistoryPage {
               }
               .width('100%')
               .height('100%')
-              .backgroundColor('#40000000')
               .justifyContent(FlexAlign.Center)
             }
             else
@@ -198,6 +218,7 @@ export struct ShowCloudBackupHistoryPage {
     })
   }
 
+  /** 备份记录卡片：左侧图标+元数据（日期/令牌数/大小/加密标识），右侧操作按钮（恢复/删除） */
   @Builder
   BackupRecordItem(record: CloudBackupRecord, isCurrentDevice: boolean) {
     Column() {
@@ -307,6 +328,7 @@ export struct ShowCloudBackupHistoryPage {
     .shadow({ radius: 10, color: $r('app.color.shadow'), offsetX: 10, offsetY: 10 })
   }
 
+  /** 文件大小格式化：<1KB 显示字节，否则显示 KB */
   private formatSize(bytes: number): string {
     if (bytes < 1024) {
       return `${bytes} B`;
@@ -314,6 +336,7 @@ export struct ShowCloudBackupHistoryPage {
     return `${(bytes / 1024).toFixed(1)} KB`;
   }
 
+  /** 恢复确认弹窗：底部 AlertDialog，确认后调用 triggerRestore 解密并写入令牌 */
   private showRestoreConfirmDialog(record: CloudBackupRecord): void {
     this.getUIContext().showAlertDialog({
       title: $r('app.string.cloud_backup_restore_confirm_title'),
@@ -339,6 +362,7 @@ export struct ShowCloudBackupHistoryPage {
     });
   }
 
+  /** 删除确认弹窗：仅当前设备的备份可删除，底部 AlertDialog 二次确认 */
   private showDeleteConfirmDialog(record: CloudBackupRecord): void {
     this.getUIContext().showAlertDialog({
       title: $r('app.string.cloud_backup_delete_confirm_title'),
@@ -364,6 +388,7 @@ export struct ShowCloudBackupHistoryPage {
     });
   }
 
+  /** 触发恢复：调用 CloudBackupManager 解密备份文件并逐条 upsert 令牌到本地存储 */
   private triggerRestore(recordId: string): void {
     this.isLoading = true;
     this.backupManager.restoreFromBackupRecord(recordId).then((success: boolean) => {
@@ -376,6 +401,7 @@ export struct ShowCloudBackupHistoryPage {
     });
   }
 
+  /** 触发删除：调用 CloudBackupManager 删除云端文件 + 同步，成功后更新 lastSyncTime 并刷新列表 */
   private triggerDelete(recordId: string): void {
     this.isLoading = true;
     this.backupManager.deleteBackupRecord(recordId).then((success: boolean) => {
@@ -390,21 +416,21 @@ export struct ShowCloudBackupHistoryPage {
     });
   }
 
+  /**
+   * 删除备份记录后更新 lastSyncTime：
+   * 如果删除的是今天的备份，尝试用剩余今天记录的最新时间戳替换；
+   * 若今天无剩余记录，则设为昨天末尾时间戳。
+   */
   private updateLastSyncTimeAfterDelete(deletedRecordId: string): void {
-    const lastTime = AppPreference.getPreference(PREF_KEYS.CLOUD_SYNC_LAST_TIME) as string;
-    if (!lastTime || lastTime.length < 10) {
-      return;
-    }
-    const today = new Date();
-    const todayStr = `${today.getFullYear()}-${this.padZero(today.getMonth() + 1)}-${this.padZero(today.getDate())}`;
-    if (!lastTime.startsWith(todayStr)) {
+    const rawTime = AppPreference.getPreference(PREF_KEYS.CLOUD_SYNC_LAST_TIME) as string;
+    const lastTs = SyncTimeHelper.parseStoredTimestamp(rawTime);
+    if (lastTs <= 0 || !SyncTimeHelper.isToday(lastTs)) {
       return;
     }
     let deletedIsToday = false;
     for (const record of this.backupRecords) {
       if (record.id === deletedRecordId) {
-        const recordDate = `${new Date(record.timestamp).getFullYear()}-${this.padZero(new Date(record.timestamp).getMonth() + 1)}-${this.padZero(new Date(record.timestamp).getDate())}`;
-        if (recordDate === todayStr) {
+        if (SyncTimeHelper.isToday(record.timestamp)) {
           deletedIsToday = true;
         }
         break;
@@ -413,27 +439,19 @@ export struct ShowCloudBackupHistoryPage {
     if (!deletedIsToday) {
       return;
     }
-    let latestRemaining: string = '';
+    let latestRemainingTs: number = 0;
     for (const record of this.backupRecords) {
       if (record.id === deletedRecordId) {
         continue;
       }
-      const recordDate = `${new Date(record.timestamp).getFullYear()}-${this.padZero(new Date(record.timestamp).getMonth() + 1)}-${this.padZero(new Date(record.timestamp).getDate())}`;
-      if (recordDate === todayStr) {
-        latestRemaining = record.date;
-        break;
+      if (SyncTimeHelper.isToday(record.timestamp) && record.timestamp > latestRemainingTs) {
+        latestRemainingTs = record.timestamp;
       }
     }
-    if (latestRemaining.length > 0) {
-      AppPreference.setPreference(PREF_KEYS.CLOUD_SYNC_LAST_TIME, latestRemaining);
+    if (latestRemainingTs > 0) {
+      AppPreference.setPreference(PREF_KEYS.CLOUD_SYNC_LAST_TIME, `${latestRemainingTs}`);
     } else {
-      const yesterday = new Date(today.getTime() - 86400000);
-      const yesterdayStr = `${yesterday.getFullYear()}-${this.padZero(yesterday.getMonth() + 1)}-${this.padZero(yesterday.getDate())} 23:59`;
-      AppPreference.setPreference(PREF_KEYS.CLOUD_SYNC_LAST_TIME, yesterdayStr);
+      AppPreference.setPreference(PREF_KEYS.CLOUD_SYNC_LAST_TIME, `${SyncTimeHelper.getYesterdayEndTs()}`);
     }
-  }
-
-  private padZero(n: number): string {
-    return n < 10 ? `0${n}` : `${n}`;
   }
 }

--- a/entry/src/main/ets/pages/ShowCloudSyncDetailsPage.ets
+++ b/entry/src/main/ets/pages/ShowCloudSyncDetailsPage.ets
@@ -12,23 +12,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { bundleManager,common, Want  } from '@kit.AbilityKit';
+import { common, Want } from '@kit.AbilityKit';
 import { AppStorageV2, PromptAction, promptAction,LengthMetrics } from '@kit.ArkUI';
 import { SettingItem } from '../components/SettingItem';
-import { deviceInfo } from '@kit.BasicServicesKit';
 import { AppPreference, SettingValue, PREF_KEYS, ROUTE_NAMES } from '../utils/AppPreference';
 import { SubItemButton } from '../components/SubItemButton';
-import { TokenStore } from '../utils/TokenStore';
 import { SubItemDivider } from '../components/SubItemDivider';
 import { AppWindowInfo } from '../entryability/EntryAbility';
 import { showSnackBar, SnackBarNotifyType } from '../utils/HdsSnackBarUtils';
 import { CloudBackupManager } from '../utils/CloudBackupManager';
-import { HuaweiAccountManager, HuaweiUserInfo } from '../utils/HuaweiAccountManager';
+import { HuaweiAccountManager } from '../utils/HuaweiAccountManager';
 import { hdsMaterial, HdsNavDestination, HdsNavDestinationTitleMode, ScrollEffectType } from '@kit.UIDesignKit';
 import { CommonConstants } from '../utils/CommonConstants';
 import { cloudSync } from '@kit.CoreFileKit';
 import { BusinessError } from '@kit.BasicServicesKit';
 import { hilog } from '@kit.PerformanceAnalysisKit';
+import { taskpool } from '@kit.ArkTS';
+import { checkCloudBackupRecords } from '../utils/CloudSyncTask';
+import { SyncTimeHelper } from '../utils/SyncTimeHelper';
 
 const TAG = 'ShowCloudSyncDetailsPage';
 const DOMAIN = 0xFF00;
@@ -41,10 +42,8 @@ export struct ShowCloudSyncDetailsPage {
   @Require @Param scrollEffectType: ScrollEffectType = ScrollEffectType.IMMERSIVE_GRADIENT_BLUR;
   @Local cloudSyncEnabled: SettingValue = false;
   @Local lastSyncTime: string = '';
-  @Local tokenCount: number = 0;
   @Local Is_loaded: boolean = true;
   @Local isHuaweiLoggedIn: boolean = false;
-  @Local huaweiNickname: string = '';
   @Local syncState: number = -1;
   @Local syncError: number = 0;
   @Local loadingText: ResourceStr = '';
@@ -53,49 +52,54 @@ export struct ShowCloudSyncDetailsPage {
   private scroller: Scroller = new Scroller();
   private fileSync: cloudSync.FileSync = new cloudSync.FileSync();
   private lastSyncTriggerTime: number = 0;
+  private isInitialSyncRunning: boolean = false;
+  private lastInitialSyncTime: number = 0;
   private readonly SYNC_COOLDOWN_MS: number = 60000;
+  private readonly INITIAL_SYNC_COOLDOWN_MS: number = 600000;
   private syncProgressCallback = (pg: cloudSync.SyncProgress) => {
     this.syncState = pg.state as number;
     this.syncError = pg.error as number;
   }
 
+  /** 页面生命周期：加载偏好设置、注册 FileSync 进度回调、按需触发初始同步 */
   aboutToAppear(): void {
-    this.cloudSyncEnabled = AppPreference.getPreference(PREF_KEYS.APPEARANCE_HUAWEI_CLOUD_SYNC_ENABLE);
-    this.lastSyncTime = AppPreference.getPreference(PREF_KEYS.CLOUD_SYNC_LAST_TIME) as string ?? '';
-    this.syncHuaweiAccountState();
-    if (!this.isHuaweiLoggedIn) {
-      return;
-    }
-    TokenStore.getInstance().getTokens().then(tokens => {
-      this.tokenCount = tokens.length;
-    });
     try {
-      this.fileSync.on('progress', this.syncProgressCallback);
-    } catch (err) {
-      let e = err as BusinessError;
-      hilog.error(DOMAIN, TAG, `FileSync on progress failed: ${e.code} ${e.message}`);
+      this.cloudSyncEnabled = AppPreference.getPreference(PREF_KEYS.APPEARANCE_HUAWEI_CLOUD_SYNC_ENABLE);
+      const rawTime = AppPreference.getPreference(PREF_KEYS.CLOUD_SYNC_LAST_TIME) as string ?? '';
+      this.lastSyncTime = SyncTimeHelper.formatTimestamp(SyncTimeHelper.parseStoredTimestamp(rawTime));
+      this.syncHuaweiAccountState();
+      if (!this.isHuaweiLoggedIn) {
+        return;
+      }
+      try {
+        this.fileSync.on('progress', this.syncProgressCallback);
+      } catch (err) {
+        let e = err as BusinessError;
+        hilog.error(DOMAIN, TAG, `FileSync on progress failed: ${e.code} ${e.message}`);
+      }
+      if (this.cloudSyncEnabled) {
+        this.triggerInitialSyncAsync();
+      }
     }
-    if (this.cloudSyncEnabled) {
-      this.triggerInitialSync();
+    finally {
+      this.Is_loaded=false;
     }
-    this.Is_loaded=false;
+
   }
 
+  /** 页面生命周期：注销 FileSync 进度回调 */
   aboutToDisappear(): void {
     try {
       this.fileSync.off('progress', this.syncProgressCallback);
     } catch (err) {
       let e = err as BusinessError;
-      console.error(`FileSync off progress failed: ${e.code} ${e.message}`);
+      hilog.error(DOMAIN, TAG, `FileSync off progress failed: ${e.code} ${e.message}`);
     }
   }
-
+  /** 同步华为账号管理器的登录态到组件 @Local 变量，用于 UI 条件渲染 */
   private syncHuaweiAccountState(): void {
     const accountMgr = HuaweiAccountManager.getInstance();
     this.isHuaweiLoggedIn = accountMgr.userLogin;
-    if (accountMgr.userAccount) {
-      this.huaweiNickname = accountMgr.userAccount.nickname;
-    }
   }
 
   build() {
@@ -110,11 +114,10 @@ export struct ShowCloudSyncDetailsPage {
                     .width(LengthMetrics.vp(80).value).height(LengthMetrics.vp(80).value)
                   Text(this.loadingText)
                     .fontSize($r('sys.float.ohos_id_text_size_body1'))
-                   .fontColor(Color.White)
+                   .fontColor($r('sys.color.font_primary'))
                }
               .width('100%')
               .height('100%')
-              .backgroundColor('#40000000')
               .justifyContent(FlexAlign.Center)
             } else {
               List({ space: LengthMetrics.vp(10).value, scroller: this.scroller }) {
@@ -122,8 +125,13 @@ export struct ShowCloudSyncDetailsPage {
                   .height(CommonConstants.AVOID_TOP_BASE_HEIGHT)
 
                 ListItem() {
-                  SettingItem({ title: $r('app.string.cloud_sync_status') }) {
+                  SettingItem({ title: $r('app.string.cloud_sync_sync_state') }) {
                     Row() {
+                      Text($r('app.string.cloud_sync_status'))
+                        .fontSize($r('sys.float.ohos_id_text_size_body2'))
+                        .fontColor($r('sys.color.ohos_id_color_text_secondary'))
+                        .fontWeight(FontWeight.Regular)
+                        .layoutWeight(1)
                       Text(this.cloudSyncEnabled ?
                         $r('app.string.cloud_sync_enabled') : $r('app.string.cloud_sync_disabled'))
                         .fontSize($r('sys.float.ohos_id_text_size_body2'))
@@ -131,89 +139,41 @@ export struct ShowCloudSyncDetailsPage {
                           $r('sys.color.ohos_id_color_text_primary') :
                           $r('sys.color.ohos_id_color_text_secondary'))
                         .fontWeight(FontWeight.Medium)
-                        .textAlign(TextAlign.Start)
+                    }
+                    .width('100%')
+                    .padding({ top: $r('sys.float.padding_level8'), right:$r('sys.float.padding_level8'), bottom: 0, left: $r('sys.float.padding_level8') })
+
+                    ListItem() {
+                      Text($r('app.string.cloud_sync_status_hint'))
+                        .fontSize($r('sys.float.ohos_id_text_size_caption'))
+                        .fontColor($r('sys.color.ohos_id_color_text_secondary'))
+                        .width('100%')
                     }
                     .padding($r('sys.float.padding_level8'))
-                  }
-                }
-                .padding({ left: $r('sys.float.padding_level8'), right: $r('sys.float.padding_level8') })
+                    SubItemDivider()
 
-                ListItem() {
-                  Text($r('app.string.cloud_sync_status_hint'))
-                    .fontSize($r('sys.float.ohos_id_text_size_caption'))
-                    .fontColor($r('sys.color.ohos_id_color_text_secondary'))
-                    .width('100%')
-                    .padding({ left: LengthMetrics.vp(2).value, right: LengthMetrics.vp(2).value })
-                }
-                .padding({ left: $r('sys.float.padding_level8'), right: $r('sys.float.padding_level8') })
-
-                ListItem() {
-                  SettingItem({ title: '' }) {
-                    SubItemButton({
-                      symbol: $r('sys.symbol.gearshape'),
-                      text: $r('app.string.cloud_sync_open_cloud_space')
-                    })
-                      .onClick(() => {
-                        this.startCloudSpaceSettings();
-                      })
-                  }
-                }
-                .padding({ left: $r('sys.float.padding_level8'), right: $r('sys.float.padding_level8') })
-
-
-                ListItem() {
-                  SettingItem({ title: $r('app.string.cloud_sync_account') }) {
                     Row() {
-                      Row({ space: LengthMetrics.vp(10).value }) {
-                        SymbolGlyph($r('sys.symbol.person'))
-                          .fontSize(LengthMetrics.vp(20).value)
-                          .fontColor([$r('app.color.str_main')])
-                        Text(this.isHuaweiLoggedIn ?
-                          this.huaweiNickname : $r('app.string.cloud_sync_not_logged_in'))
-                          .fontSize($r('sys.float.ohos_id_text_size_body2'))
-                          .fontColor(this.isHuaweiLoggedIn ?
-                            $r('sys.color.ohos_id_color_text_primary') :
-                            $r('sys.color.ohos_id_color_text_secondary'))
-                          .fontWeight(FontWeight.Medium)
-                          .textAlign(TextAlign.Start)
-                      }
-                      .padding($r('sys.float.padding_level8'))
-                    }
-                  }
-                }
-                .padding({ left: $r('sys.float.padding_level8'), right: $r('sys.float.padding_level8') })
-
-                ListItem() {
-                  SettingItem({ title: $r('app.string.cloud_sync_last_time') }) {
-                    Row() {
+                      Text($r('app.string.cloud_sync_last_time'))
+                        .fontSize($r('sys.float.ohos_id_text_size_body2'))
+                        .fontColor($r('sys.color.ohos_id_color_text_secondary'))
+                        .fontWeight(FontWeight.Regular)
+                        .layoutWeight(1)
                       Text((this.lastSyncTime != null && this.lastSyncTime != "") ? this.lastSyncTime : $r('app.string.cloud_sync_never'))
                         .fontSize($r('sys.float.ohos_id_text_size_body2'))
                         .fontColor($r('sys.color.ohos_id_color_text_primary'))
                         .fontWeight(FontWeight.Medium)
-                        .textAlign(TextAlign.Start)
                     }
+                    .width('100%')
                     .padding($r('sys.float.padding_level8'))
-                  }
-                }
-                .padding({ left: $r('sys.float.padding_level8'), right: $r('sys.float.padding_level8') })
 
-                ListItem() {
-                  SettingItem({ title: $r('app.string.cloud_sync_token_count') }) {
+                    SubItemDivider()
+
                     Row() {
-                      Text(`${this.tokenCount}`)
+                      Text($r('app.string.cloud_sync_encryption'))
                         .fontSize($r('sys.float.ohos_id_text_size_body2'))
-                        .fontColor($r('sys.color.ohos_id_color_text_primary'))
-                        .fontWeight(FontWeight.Medium)
-                        .textAlign(TextAlign.Start)
-                    }
-                    .padding($r('sys.float.padding_level8'))
-                  }
-                }
-                .padding({ left: $r('sys.float.padding_level8'), right: $r('sys.float.padding_level8') })
-
-                ListItem() {
-                  SettingItem({ title: $r('app.string.cloud_sync_encryption') }) {
-                    Row() {
+                        .fontColor($r('sys.color.ohos_id_color_text_secondary'))
+                        .fontWeight(FontWeight.Regular)
+                        .layoutWeight(1)
                       Text(this.isHuaweiLoggedIn ?
                         $r('app.string.cloud_sync_encryption_huawei_account') :
                         $r('app.string.cloud_sync_encryption_none'))
@@ -222,35 +182,34 @@ export struct ShowCloudSyncDetailsPage {
                           $r('sys.color.ohos_id_color_text_primary') :
                           $r('sys.color.ohos_id_color_text_secondary'))
                         .fontWeight(FontWeight.Medium)
-                        .textAlign(TextAlign.Start)
                     }
+                    .width('100%')
                     .padding($r('sys.float.padding_level8'))
-                  }
-                }
-                .padding({ left: $r('sys.float.padding_level8'), right: $r('sys.float.padding_level8') })
 
-                ListItem() {
-                  SettingItem({ title: $r('app.string.cloud_sync_network') }) {
+                    SubItemDivider()
+
                     Row() {
-                      Row({ space: LengthMetrics.vp(6).value }) {
-                        SymbolGlyph($r('sys.symbol.wifi'))
-                          .fontSize(LengthMetrics.vp(16).value)
-                          .fontColor([$r('app.color.str_main')])
-                        Text($r('app.string.cloud_sync_wifi_only'))
-                          .fontSize($r('sys.float.ohos_id_text_size_body2'))
-                          .fontColor($r('sys.color.ohos_id_color_text_primary'))
-                          .fontWeight(FontWeight.Medium)
-                          .textAlign(TextAlign.Start)
-                      }
-                      .padding($r('sys.float.padding_level8'))
+                      Text($r('app.string.cloud_sync_network'))
+                        .fontSize($r('sys.float.ohos_id_text_size_body2'))
+                        .fontColor($r('sys.color.ohos_id_color_text_secondary'))
+                        .fontWeight(FontWeight.Regular)
+                        .layoutWeight(1)
+                      Text($r('app.string.cloud_sync_wifi_only'))
+                        .fontSize($r('sys.float.ohos_id_text_size_body2'))
+                        .fontColor($r('sys.color.ohos_id_color_text_primary'))
+                        .fontWeight(FontWeight.Medium)
                     }
-                  }
-                }
-                .padding({ left: $r('sys.float.padding_level8'), right: $r('sys.float.padding_level8') })
+                    .width('100%')
+                    .padding($r('sys.float.padding_level8'))
 
-                ListItem() {
-                  SettingItem({ title: $r('app.string.cloud_sync_sync_state') }) {
+                    SubItemDivider()
+
                     Row() {
+                      Text($r('app.string.cloud_sync_sync_state'))
+                        .fontSize($r('sys.float.ohos_id_text_size_body2'))
+                        .fontColor($r('sys.color.ohos_id_color_text_secondary'))
+                        .fontWeight(FontWeight.Regular)
+                        .layoutWeight(1)
                       Row({ space: LengthMetrics.vp(6).value }) {
                         if (this.syncState === 0 || this.syncState === 2) {
                           LoadingProgress()
@@ -262,60 +221,65 @@ export struct ShowCloudSyncDetailsPage {
                           .fontSize($r('sys.float.ohos_id_text_size_body2'))
                           .fontColor(this.getSyncStateColor())
                           .fontWeight(FontWeight.Medium)
-                          .textAlign(TextAlign.Start)
                       }
-                      .padding($r('sys.float.padding_level8'))
                     }
-                  }
-                }
-                .padding({ left: $r('sys.float.padding_level8'), right: $r('sys.float.padding_level8') })
+                    .width('100%')
+                    .padding($r('sys.float.padding_level8'))
 
-                if (this.syncError !== 0) {
-                  ListItem() {
-                    SettingItem({ title: $r('app.string.cloud_sync_sync_error') }) {
+                    if (this.syncError !== 0) {
+                      SubItemDivider()
+
                       Row() {
+                        Text($r('app.string.cloud_sync_sync_error'))
+                          .fontSize($r('sys.float.ohos_id_text_size_body2'))
+                          .fontColor($r('sys.color.ohos_id_color_text_secondary'))
+                          .fontWeight(FontWeight.Regular)
+                          .layoutWeight(1)
                         Text(this.getSyncErrorText())
                           .fontSize($r('sys.float.ohos_id_text_size_body2'))
                           .fontColor($r('sys.color.ohos_id_color_warning'))
                           .fontWeight(FontWeight.Medium)
-                          .textAlign(TextAlign.Start)
                       }
+                      .width('100%')
                       .padding($r('sys.float.padding_level8'))
                     }
                   }
-                  .padding({ left: $r('sys.float.padding_level8'), right: $r('sys.float.padding_level8') })
-                }
-
-                ListItem() {
-                  SettingItem({ title: '' }) {
-                    SubItemButton({
-                      symbol: $r('sys.symbol.mobiledata'),
-                      text: $r('app.string.cloud_sync_trigger_sync')
-                    })
-                      .onClick(() => {
-                        this.triggerFileSync();
-                      })
-                  }
                 }
                 .padding({ left: $r('sys.float.padding_level8'), right: $r('sys.float.padding_level8') })
 
-                ListItem() {
-                  SettingItem({ title: '' }) {
-                    SubItemButton({
-                      symbol: $r('sys.symbol.arrow_clockwise'),
-                      text: $r('app.string.data_sync_manual')
-                    })
-                      .onClick(() => {
-                        this.loadingText = $r('app.string.cloud_sync_backing_up');
-                        this.Is_loaded = true;
-                        this.triggerCloudSync();
-                      })
-                  }
-                }
-                .padding({ left: $r('sys.float.padding_level8'), right: $r('sys.float.padding_level8') })
+
 
                 ListItem() {
-                  SettingItem({ title: '' }) {
+                  SettingItem({ title: $r('app.string.cloud_sync_operations') }) {
+                    if (this.cloudSyncEnabled) {
+                      SubItemButton({
+                        symbol: $r('sys.symbol.mobiledata'),
+                        text: $r('app.string.cloud_sync_trigger_sync'),
+                        description: $r('app.string.cloud_sync_trigger_sync_des')
+                      })
+                        .onClick(() => {
+                          this.triggerFileSync();
+                        })
+
+                      SubItemDivider()
+
+                      SubItemButton({
+                        symbol: $r('sys.symbol.arrow_clockwise'),
+                        text: $r('app.string.data_sync_manual'),
+                        description: $r('app.string.data_sync_manual_des')
+                      })
+                        .onClick(() => {
+                          if (!this.cloudSyncEnabled) {
+                            return;
+                          }
+                          this.loadingText = $r('app.string.cloud_sync_backing_up');
+                          this.Is_loaded = true;
+                          this.triggerCloudSync();
+                        })
+
+                      SubItemDivider()
+                    }
+
                     SubItemButton({
                       symbol: $r('sys.symbol.arrow_counterclockwise_clock'),
                       text: $r('app.string.cloud_backup_history_title'),
@@ -324,12 +288,19 @@ export struct ShowCloudSyncDetailsPage {
                       .onClick(() => {
                         this.pageInfos?.pushPathByName(ROUTE_NAMES.ShowCloudBackupHistoryPage, null);
                       })
-                  }
-                }
-                .padding({ left: $r('sys.float.padding_level8'), right: $r('sys.float.padding_level8') })
 
-                ListItem() {
-                  SettingItem({ title: '' }) {
+                    SubItemDivider()
+
+                    SubItemButton({
+                      symbol: $r('sys.symbol.gearshape'),
+                      text: $r('app.string.cloud_sync_open_cloud_space')
+                    })
+                      .onClick(() => {
+                        this.startCloudSpaceSettings();
+                      })
+
+                    SubItemDivider()
+
                     SubItemButton({
                       symbol: $r('sys.symbol.trash'),
                       text: $r('app.string.cloud_sync_clear_storage')
@@ -341,31 +312,8 @@ export struct ShowCloudSyncDetailsPage {
                 }
                 .padding({ left: $r('sys.float.padding_level8'), right: $r('sys.float.padding_level8') })
 
-                ListItem() {
-                  SettingItem({ title: $r('app.string.data_dev_info') }) {
-                    Row() {
-                      Text(deviceInfo.marketName)
-                        .fontSize($r('sys.float.ohos_id_text_size_body2'))
-                        .fontColor($r('sys.color.ohos_id_color_text_primary'))
-                        .fontWeight(FontWeight.Medium)
-                        .textAlign(TextAlign.Start)
-                    }
-                    .padding($r('sys.float.padding_level8'))
-
-                    SubItemDivider()
-
-                    Row() {
-                      Text(deviceInfo.ODID)
-                        .fontSize($r('sys.float.ohos_id_text_size_body2'))
-                        .fontColor($r('sys.color.ohos_id_color_text_primary'))
-                        .fontWeight(FontWeight.Medium)
-                        .textAlign(TextAlign.Start)
-                    }
-                    .padding($r('sys.float.padding_level8'))
-                  }
-                }
-                .padding({ left: $r('sys.float.padding_level8'), right: $r('sys.float.padding_level8') })
-
+                ListItem()
+                  .height(CommonConstants.AVOID_TOP_BASE_HEIGHT)
               }
               .chainAnimation(true)
               .edgeEffect(EdgeEffect.Spring, { alwaysEnabled: true })
@@ -424,6 +372,7 @@ export struct ShowCloudSyncDetailsPage {
     })
   }
 
+  /** FileSync 状态码 → i18n 文本映射（0=上传中, 1=上传失败, 2=下载中, 3=下载失败, 4=完成, 5=已停止） */
   private getSyncStateText(): ResourceStr {
     if (this.syncState === 0) {
       return $r('app.string.cloud_sync_state_uploading');
@@ -446,6 +395,7 @@ export struct ShowCloudSyncDetailsPage {
     return $r('app.string.cloud_sync_state_idle');
   }
 
+  /** FileSync 状态码 → 颜色映射（失败=警告色, 完成=主色, 进行中=主题色, 其他=次级色） */
   private getSyncStateColor(): ResourceColor {
     if (this.syncState === 1 || this.syncState === 3) {
       return $r('sys.color.ohos_id_color_warning');
@@ -459,6 +409,7 @@ export struct ShowCloudSyncDetailsPage {
     return $r('sys.color.ohos_id_color_text_secondary');
   }
 
+  /** FileSync 错误码 → i18n 文本映射（网络/WiFi/电量/存储/温度/服务器异常） */
   private getSyncErrorText(): ResourceStr {
     if (this.syncError === 1) {
       return $r('app.string.cloud_sync_error_network_unavailable');
@@ -487,8 +438,9 @@ export struct ShowCloudSyncDetailsPage {
     return $r('app.string.cloud_sync_error_no_error');
   }
 
+  /** 手动触发从云端恢复：启动 FileSync，含60秒冷却防抖 */
   private triggerFileSync(): void {
-    if (!this.isHuaweiLoggedIn) {
+    if (!this.isHuaweiLoggedIn || !this.cloudSyncEnabled) {
       return;
     }
     const now = Date.now();
@@ -516,6 +468,7 @@ export struct ShowCloudSyncDetailsPage {
     }
   }
 
+  /** 清空云端存储操作菜单：选择"仅清空本设备"或"清空所有设备"，二次确认后执行 */
   private showClearCloudStorageDialog(): void {
     if (!this.isHuaweiLoggedIn) {
       return;
@@ -549,6 +502,7 @@ export struct ShowCloudSyncDetailsPage {
     }
   }
 
+  /** 清空确认弹窗：底部弹出 AlertDialog，确认后调用 triggerClearCloudStorage */
   private showClearConfirmDialog(clearAll: boolean): void {
     const msg = clearAll
       ? $r('app.string.cloud_sync_clear_all_confirm_msg')
@@ -577,19 +531,22 @@ export struct ShowCloudSyncDetailsPage {
     });
   }
 
+  /** 手动触发立即备份：调用 CloudBackupManager.backupToCloud 上传令牌到云端 */
   private triggerCloudSync(): void {
-    if (!this.isHuaweiLoggedIn) {
+    if (!this.isHuaweiLoggedIn || !this.cloudSyncEnabled) {
       this.Is_loaded = false;
       return;
     }
     CloudBackupManager.getInstance().backupToCloud().then(success => {
       this.Is_loaded = false;
       if (success) {
-        this.lastSyncTime = AppPreference.getPreference(PREF_KEYS.CLOUD_SYNC_LAST_TIME) as string;
+        const rawTime = AppPreference.getPreference(PREF_KEYS.CLOUD_SYNC_LAST_TIME) as string;
+        this.lastSyncTime = SyncTimeHelper.formatTimestamp(SyncTimeHelper.parseStoredTimestamp(rawTime));
       }
     });
   }
 
+  /** 清空云端备份后更新 lastSyncTime 为昨天末尾，使 UI 显示过期时间 */
   private triggerClearCloudStorage(clearAll: boolean): void {
     this.loadingText = $r('app.string.cloud_sync_clearing');
     this.Is_loaded = true;
@@ -598,18 +555,14 @@ export struct ShowCloudSyncDetailsPage {
       : CloudBackupManager.getInstance().clearDeviceCloudStorage();
     clearPromise.then(() => {
       this.Is_loaded = false;
-      const yesterday = new Date(Date.now() - 86400000);
-      const yesterdayStr = `${yesterday.getFullYear()}-${this.padZero(yesterday.getMonth() + 1)}-${this.padZero(yesterday.getDate())} 23:59`;
-      AppPreference.setPreference(PREF_KEYS.CLOUD_SYNC_LAST_TIME, yesterdayStr);
-      this.lastSyncTime = yesterdayStr;
+      const yesterdayTs = SyncTimeHelper.getYesterdayEndTs();
+      AppPreference.setPreference(PREF_KEYS.CLOUD_SYNC_LAST_TIME, `${yesterdayTs}`);
+      this.lastSyncTime = SyncTimeHelper.formatTimestamp(yesterdayTs);
       showSnackBar($r('app.string.cloud_sync_clear_storage_success'), SnackBarNotifyType.SUCCESS);
     });
   }
 
-  private padZero(n: number): string {
-    return n < 10 ? `0${n}` : `${n}`;
-  }
-
+  /** 跳转华为云空间系统设置页面（com.huawei.hmos.settings） */
   private startCloudSpaceSettings(): void {
   let want: Want = {
     bundleName: 'com.huawei.hmos.settings',
@@ -623,22 +576,60 @@ export struct ShowCloudSyncDetailsPage {
   });
 }
 
-  private triggerInitialSync(): void {
-    CloudBackupManager.getInstance().init().then(() => {
-      return CloudBackupManager.getInstance().listBackupHistory();
-    }).then((records) => {
-      if (records.length === 0) {
-        hilog.info(DOMAIN, TAG, 'triggerInitialSync: no local records, triggering FileSync');
+  /**
+   * 初始同步：页面打开时在 TaskPool 后台线程检查云端备份记录数，
+   * 仅当本地无备份记录时触发 FileSync 从云端拉取。
+   * 三重防护：isInitialSyncRunning 防并发，lastInitialSyncTime 防短时间内重复，
+   * CLOUD_SYNC_LAST_TIME 时间戳判断距上次同步是否超过10分钟。
+   */
+  private triggerInitialSyncAsync(): void {
+    if (this.isInitialSyncRunning) {
+      hilog.info(DOMAIN, TAG, 'triggerInitialSyncAsync: already running, skip');
+      return;
+    }
+    const now = Date.now();
+    if (this.lastInitialSyncTime > 0 && (now - this.lastInitialSyncTime) < this.INITIAL_SYNC_COOLDOWN_MS) {
+      hilog.info(DOMAIN, TAG, `triggerInitialSyncAsync: cooldown, last run ${now - this.lastInitialSyncTime}ms ago, skip`);
+      return;
+    }
+    const rawTime = AppPreference.getPreference(PREF_KEYS.CLOUD_SYNC_LAST_TIME) as string;
+    const lastTs = SyncTimeHelper.parseStoredTimestamp(rawTime);
+    if (lastTs > 0 && SyncTimeHelper.isWithinMinutes(lastTs, this.INITIAL_SYNC_COOLDOWN_MS / 60000)) {
+      hilog.info(DOMAIN, TAG, `triggerInitialSyncAsync: last sync ts=${lastTs}, within ${this.INITIAL_SYNC_COOLDOWN_MS / 60000}min, skip`);
+      return;
+    }
+    this.isInitialSyncRunning = true;
+    this.lastInitialSyncTime = now;
+    const cloudDir = this.appCtx.cloudFileDir;
+    hilog.info(DOMAIN, TAG, 'triggerInitialSyncAsync: dispatching to taskpool');
+    taskpool.execute(checkCloudBackupRecords, cloudDir).then((result: Object) => {
+      const recordCount = result as number;
+      hilog.info(DOMAIN, TAG, `triggerInitialSyncAsync: taskpool returned recordCount=${recordCount}`);
+      if (recordCount === 0) {
         this.loadingText = $r('app.string.cloud_sync_loading_history');
         this.Is_loaded = true;
-        this.fileSync.start().then(() => {
+        try {
+          this.fileSync.start().then(() => {
+            this.Is_loaded = false;
+            this.isInitialSyncRunning = false;
+            hilog.info(DOMAIN, TAG, 'triggerInitialSyncAsync: FileSync completed');
+          }).catch((err: BusinessError) => {
+            this.Is_loaded = false;
+            this.isInitialSyncRunning = false;
+            hilog.error(DOMAIN, TAG, `triggerInitialSyncAsync: FileSync failed: ${err.code} ${err.message}`);
+          });
+        } catch (err) {
           this.Is_loaded = false;
-          hilog.info(DOMAIN, TAG, 'triggerInitialSync: FileSync completed');
-        }).catch((err: BusinessError) => {
-          this.Is_loaded = false;
-          hilog.error(DOMAIN, TAG, `triggerInitialSync: FileSync failed: ${err.code} ${err.message}`);
-        });
+          this.isInitialSyncRunning = false;
+          let e = err as BusinessError;
+          hilog.error(DOMAIN, TAG, `triggerInitialSyncAsync: FileSync exception: ${e.code} ${e.message}`);
+        }
+      } else {
+        this.isInitialSyncRunning = false;
       }
+    }).catch((err: BusinessError) => {
+      this.isInitialSyncRunning = false;
+      hilog.error(DOMAIN, TAG, `triggerInitialSyncAsync: taskpool failed: ${err.code} ${err.message}`);
     });
   }
 }

--- a/entry/src/main/ets/utils/AppPreference.ets
+++ b/entry/src/main/ets/utils/AppPreference.ets
@@ -342,7 +342,7 @@ export class AppPreference {
     // 数据库是否启用云同步
     [PREF_KEYS.DB_RDS_CLOUD_SYNC_ENABLE, false],
     // 云端同步最后时间
-    [PREF_KEYS.CLOUD_SYNC_LAST_TIME, ''],
+    [PREF_KEYS.CLOUD_SYNC_LAST_TIME, '0'],
     // 数据库是否启用跨设备流转
     [PREF_KEYS.DB_RDS_SYNC_ENABLE, false],
     // kv数据库同步时间

--- a/entry/src/main/ets/utils/CloudBackupCrypto.ets
+++ b/entry/src/main/ets/utils/CloudBackupCrypto.ets
@@ -4,16 +4,22 @@ import { cryptoFramework } from '@kit.CryptoArchitectureKit';
 
 const TAG = 'CloudBackupCrypto';
 const DOMAIN = 0xFF00;
+/** JWT-like 三段式分隔符：header.payload.signature */
 const TOKEN_SEPARATOR = '.';
+/** PBKDF2 密钥派生迭代次数，10000 次平衡安全性与性能 */
 const PBKDF2_ITERATIONS = 10000;
+/** AES-128 密钥长度（字节） */
 const KEY_SIZE = 16;
+/** 旧版 mock 文件的 salt 前缀标识，用于向后兼容检测 */
 const MOCK_SALT_PREFIX = 'mock_salt_';
 
+/** 加密模式枚举：NONE=未加密（旧 mock 格式），HUAWEI_ACCOUNT=华为账号绑定密钥加密 */
 export enum CloudBackupCryptoMode {
   NONE = 0,
   HUAWEI_ACCOUNT = 1,
 }
 
+/** 备份文件头部元数据，base64 编码后作为 JWT-like 第一段 */
 export interface CloudBackupTokenHeader {
   version: number;
   mode: CloudBackupCryptoMode;
@@ -26,6 +32,7 @@ export interface CloudBackupTokenHeader {
   deviceName: string;
 }
 
+/** 云端备份记录，用于备份历史列表展示 */
 export interface CloudBackupRecord {
   id: string;
   date: string;
@@ -47,6 +54,12 @@ export class CloudBackupTokenError extends Error {
   }
 }
 
+/**
+ * 云端备份加密/解密单例。
+ * 文件格式为 JWT-like 三段式：base64(header).base64(ciphertext).hex(sha256)
+ * 加密算法：AES-128|CBC|PKCS7，密钥派生：PBKDF2|SHA256
+ * 向后兼容：旧版 mock 文件（salt 以 mock_salt_ 开头）直接 base64 解码返回明文
+ */
 export class CloudBackupCrypto {
   private static instance: CloudBackupCrypto | null = null;
   private base64Helper: util.Base64Helper = new util.Base64Helper();
@@ -61,10 +74,23 @@ export class CloudBackupCrypto {
     return CloudBackupCrypto.instance;
   }
 
+  /** 根据华为账号登录状态决定加密模式 */
   getMode(isHuaweiLoggedIn: boolean): CloudBackupCryptoMode {
     return isHuaweiLoggedIn ? CloudBackupCryptoMode.HUAWEI_ACCOUNT : CloudBackupCryptoMode.NONE;
   }
 
+  /**
+   * 加密明文令牌数据，生成 JWT-like 三段式备份文件内容。
+   * 流程：生成随机 salt+iv → 构建 header → AES 加密 → 拼接 header.payload.signature
+   * @param plaintext 令牌 JSON 明文
+   * @param mode 加密模式（必须非 NONE）
+   * @param key 密钥材料（华为账号关联的密钥字符串）
+   * @param tokenCount 令牌数量，写入 header 用于 UI 展示
+   * @param timestamp 备份时间戳（毫秒）
+   * @param deviceId 设备 ODID
+   * @param deviceName 设备市场名称
+   * @returns 三段式加密字符串
+   */
   async encrypt(
     plaintext: string,
     mode: CloudBackupCryptoMode,
@@ -107,6 +133,11 @@ export class CloudBackupCrypto {
     return headerB64 + TOKEN_SEPARATOR + payloadB64 + TOKEN_SEPARATOR + hash;
   }
 
+  /**
+   * 解密 JWT-like 三段式备份文件内容，返回令牌 JSON 明文。
+   * 流程：拆分三段 → 验证 SHA256 签名 → 解析 header → 检测是否 mock 旧格式 → AES 解密
+   * 向后兼容：若 header.salt 以 "mock_salt_" 开头，直接 base64 解码 payload 返回明文
+   */
   async decrypt(token: string, mode: CloudBackupCryptoMode, key: string): Promise<string> {
     const segments = token.split(TOKEN_SEPARATOR);
     if (segments.length !== 3) {
@@ -142,6 +173,7 @@ export class CloudBackupCrypto {
     return result;
   }
 
+  /** 仅解析 header 段（不解密 payload），用于读取元数据如 tokenCount、deviceId 等 */
   parseTokenHeader(token: string): CloudBackupTokenHeader {
     const segments = token.split(TOKEN_SEPARATOR);
     if (segments.length !== 3) {
@@ -151,6 +183,7 @@ export class CloudBackupCrypto {
     return JSON.parse(headerJson) as CloudBackupTokenHeader;
   }
 
+  /** 验证三段式 token 的 SHA256 签名是否完整，不执行解密 */
   async verifyToken(token: string): Promise<boolean> {
     const segments = token.split(TOKEN_SEPARATOR);
     if (segments.length !== 3) {
@@ -159,6 +192,7 @@ export class CloudBackupCrypto {
     return await this.verifySha256(segments[0] + TOKEN_SEPARATOR + segments[1], segments[2]);
   }
 
+  /** 检测 token 是否为旧版 mock 格式（salt 以 "mock_salt_" 开头） */
   isMockFormat(token: string): boolean {
     try {
       const header = this.parseTokenHeader(token);
@@ -168,6 +202,7 @@ export class CloudBackupCrypto {
     }
   }
 
+  /** AES-128|CBC|PKCS7 加密：通过 PBKDF2 派生密钥后执行对称加密 */
   private async aesEncrypt(
     plaintext: Uint8Array,
     password: string,
@@ -185,6 +220,7 @@ export class CloudBackupCrypto {
     return result.data;
   }
 
+  /** AES-128|CBC|PKCS7 解密：通过 PBKDF2 派生密钥后执行对称解密 */
   private async aesDecrypt(
     ciphertext: Uint8Array,
     password: string,
@@ -202,6 +238,7 @@ export class CloudBackupCrypto {
     return result.data;
   }
 
+  /** PBKDF2|SHA256 密钥派生：将密码字符串 + salt 迭代 10000 次生成 AES-128 对称密钥 */
   private async deriveKey(password: string, salt: Uint8Array): Promise<cryptoFramework.SymKey> {
     const spec: cryptoFramework.PBKDF2Spec = {
       algName: 'PBKDF2',
@@ -242,6 +279,7 @@ export class CloudBackupCrypto {
     return this.base64Helper.decodeSync(base64Str);
   }
 
+  /** 计算 SHA256 哈希，返回十六进制字符串，用于 JWT-like 签名段 */
   private async computeSha256(data: string): Promise<string> {
     const md = cryptoFramework.createMd('SHA256');
     const inputData = new Uint8Array(buffer.from(data, 'utf-8').buffer);
@@ -250,6 +288,7 @@ export class CloudBackupCrypto {
     return buffer.from(result.data).toString('hex');
   }
 
+  /** 验证 SHA256 签名：比较计算值与期望值是否一致 */
   private async verifySha256(data: string, expectedHex: string): Promise<boolean> {
     const actualHex = await this.computeSha256(data);
     return actualHex === expectedHex;

--- a/entry/src/main/ets/utils/CloudBackupManager.ets
+++ b/entry/src/main/ets/utils/CloudBackupManager.ets
@@ -23,6 +23,7 @@ import { common } from '@kit.AbilityKit';
 import { buffer } from '@kit.ArkTS';
 import { DeviceInfoHelper } from './DeviceInfoHelper';
 import { HuaweiAccountManager } from './HuaweiAccountManager';
+import { SyncTimeHelper } from './SyncTimeHelper';
 
 const TAG = 'CloudBackupManager';
 const DOMAIN = 0xFF00;
@@ -138,9 +139,7 @@ export class CloudBackupManager {
 
     await this.syncToCloud();
 
-    const d = new Date(now);
-    const dateStr = `${d.getFullYear()}-${this.padZero(d.getMonth() + 1)}-${this.padZero(d.getDate())} ${this.padZero(d.getHours())}:${this.padZero(d.getMinutes())}`;
-    AppPreference.setPreference(PREF_KEYS.CLOUD_SYNC_LAST_TIME, dateStr);
+    AppPreference.setPreference(PREF_KEYS.CLOUD_SYNC_LAST_TIME, `${now}`);
 
     hilog.info(DOMAIN, TAG, 'backupToCloud: completed successfully');
     return true;
@@ -190,7 +189,7 @@ export class CloudBackupManager {
       for (const record of records) {
         await this.deleteBackupFile(record.id);
       }
-      AppPreference.setPreference(PREF_KEYS.CLOUD_SYNC_LAST_TIME, '');
+      AppPreference.setPreference(PREF_KEYS.CLOUD_SYNC_LAST_TIME, '0');
       hilog.info(DOMAIN, TAG, 'clearCloudStorage: completed');
       return true;
     } catch (e) {
@@ -220,7 +219,7 @@ export class CloudBackupManager {
       for (const record of deviceRecords) {
         await this.deleteBackupFile(record.id);
       }
-      AppPreference.setPreference(PREF_KEYS.CLOUD_SYNC_LAST_TIME, '');
+      AppPreference.setPreference(PREF_KEYS.CLOUD_SYNC_LAST_TIME, '0');
       hilog.info(DOMAIN, TAG, `clearDeviceCloudStorage: completed, deleted ${deviceRecords.length}`);
       return true;
     } catch (e) {
@@ -250,13 +249,10 @@ export class CloudBackupManager {
     }
 
     const lastTime = AppPreference.getPreference(PREF_KEYS.CLOUD_SYNC_LAST_TIME) as string;
-    if (lastTime && lastTime.length >= 10) {
-      const today = new Date();
-      const todayStr = `${today.getFullYear()}-${this.padZero(today.getMonth() + 1)}-${this.padZero(today.getDate())}`;
-      if (lastTime.startsWith(todayStr)) {
-        hilog.info(DOMAIN, TAG, 'checkAndAutoBackup: already backed up today, skipping');
-        return;
-      }
+    const lastTs = SyncTimeHelper.parseStoredTimestamp(lastTime);
+    if (lastTs > 0 && SyncTimeHelper.isToday(lastTs)) {
+      hilog.info(DOMAIN, TAG, 'checkAndAutoBackup: already backed up today, skipping');
+      return;
     }
 
     hilog.info(DOMAIN, TAG, 'checkAndAutoBackup: starting auto backup');

--- a/entry/src/main/ets/utils/CloudSyncTask.ets
+++ b/entry/src/main/ets/utils/CloudSyncTask.ets
@@ -1,0 +1,152 @@
+/**
+ * CloudSyncTask — 云端备份初始同步的 TaskPool 并发任务
+ *
+ * 此文件定义 @Concurrent 函数，供 taskpool.execute() 在后台线程执行，
+ * 避免 I/O 密集操作（目录检查、文件列表）阻塞 UI 主线程。
+ *
+ * 函数说明：
+ * - checkCloudBackupRecords: 确保云端目录存在，统计备份文件数量并返回
+ * - loadBackupHistoryRecords: 读取所有备份文件并解析 header 元数据，返回完整备份记录列表
+ */
+import { fileIo as fs } from '@kit.CoreFileKit';
+import { hilog } from '@kit.PerformanceAnalysisKit';
+import { buffer, util } from '@kit.ArkTS';
+import { CloudBackupRecord, CloudBackupTokenHeader } from './CloudBackupCrypto';
+import { padZero } from './CommonUtils';
+
+
+
+/**
+ * 在 TaskPool 后台线程中检查云端备份记录数量。
+ * 1. 检查云端目录是否存在，不存在则创建
+ * 2. 遍历目录文件，统计匹配 otp_backup_*.enc 模式的文件数
+ * @param cloudDir 云端目录路径（由主线程传入，避免在子线程访问 AppStorage）
+ * @returns 备份文件数量
+ */
+@Concurrent
+export async function checkCloudBackupRecords(cloudDir: string): Promise<number> {
+  let recordCount: number = 0;
+  const TAG = 'CloudSyncTask';
+  const DOMAIN = 0xFF00;
+  const BACKUP_FILE_PREFIX = 'otp_backup_';
+  const BACKUP_FILE_EXT = '.enc';
+  try {
+    try {
+      await fs.stat(cloudDir);
+    } catch (e) {
+      hilog.info(DOMAIN, TAG, `checkCloudBackupRecords: dir not exist, creating`);
+      try {
+        await fs.mkdir(cloudDir);
+      } catch (err) {
+        hilog.error(DOMAIN, TAG, `checkCloudBackupRecords: mkdir failed: ${JSON.stringify(err)}`);
+        return 0;
+      }
+    }
+
+    const files: Array<string> = fs.listFileSync(cloudDir);
+    for (let i = 0; i < files.length; i++) {
+      const fileName: string = files[i];
+      if (fileName.startsWith(BACKUP_FILE_PREFIX) && fileName.endsWith(BACKUP_FILE_EXT)) {
+        recordCount++;
+      }
+    }
+  } catch (e) {
+    hilog.error(DOMAIN, TAG, `checkCloudBackupRecords: error=${JSON.stringify(e)}`);
+  }
+
+  hilog.info(DOMAIN, TAG, `checkCloudBackupRecords: found ${recordCount} records`);
+  return recordCount;
+}
+
+/**
+ * 在 TaskPool 后台线程中加载完整备份历史记录。
+ * 1. 遍历云端目录，筛选 otp_backup_*.enc 文件
+ * 2. 读取每个文件内容，解析 JWT-like header 获取 tokenCount/deviceId/deviceName 等元数据
+ * 3. 云端文件（location=2）读取失败时降级为仅 stat 信息
+ * 4. 按时间戳降序排列返回
+ * @param cloudDir 云端目录路径（由主线程传入，避免在子线程访问 AppStorage/单例）
+ * @returns 备份记录数组
+ */
+@Concurrent
+export async function loadBackupHistoryRecords(cloudDir: string): Promise<CloudBackupRecord[]> {
+  const base64Helper: util.Base64Helper = new util.Base64Helper();
+  const records: CloudBackupRecord[] = [];
+  const TAG = 'CloudSyncTask';
+  const DOMAIN = 0xFF00;
+  const BACKUP_FILE_PREFIX = 'otp_backup_';
+  const BACKUP_FILE_EXT = '.enc';
+
+  try {
+    const files: Array<string> = fs.listFileSync(cloudDir);
+    for (let i = 0; i < files.length; i++) {
+      const fileName: string = files[i];
+      if (!fileName.startsWith(BACKUP_FILE_PREFIX) || !fileName.endsWith(BACKUP_FILE_EXT)) {
+        continue;
+      }
+
+      const filePath: string = `${cloudDir}/${fileName}`;
+      try {
+        const stat = await fs.stat(filePath);
+        const timestampStr: string = fileName.replace(BACKUP_FILE_PREFIX, '').replace(BACKUP_FILE_EXT, '');
+        const timestamp: number = parseInt(timestampStr);
+
+        if (isNaN(timestamp)) {
+          continue;
+        }
+
+        let tokenCount: number = 0;
+        let fileSize: number = stat.size;
+        let deviceId: string = '';
+        let deviceName: string = '';
+        try {
+          const file = fs.openSync(filePath, fs.OpenMode.READ_ONLY);
+          const bufferArray: ArrayBuffer = new ArrayBuffer(stat.size);
+          const readLen: number = fs.readSync(file.fd, bufferArray);
+          fs.closeSync(file);
+          const uint8Array: Uint8Array = new Uint8Array(bufferArray.slice(0, readLen));
+          const tokenContent: string = buffer.from(uint8Array).toString('utf-8');
+          const segments: string[] = tokenContent.split('.');
+          if (segments.length === 3) {
+            const headerBytes: Uint8Array = base64Helper.decodeSync(segments[0]);
+            const headerJson: string = buffer.from(headerBytes).toString('utf-8');
+            const header: CloudBackupTokenHeader = JSON.parse(headerJson) as CloudBackupTokenHeader;
+            tokenCount = header.tokenCount;
+            fileSize = header.size;
+            deviceId = header.deviceId;
+            deviceName = header.deviceName;
+          }
+        } catch (e) {
+          hilog.warn(DOMAIN, TAG, `loadBackupHistoryRecords: parse header failed for ${fileName}`);
+        }
+
+        const d: Date = new Date(timestamp);
+        const dateStr: string =
+          `${d.getFullYear()}-${padZero(d.getMonth() + 1)}-${padZero(d.getDate())} ${padZero(d.getHours())}:${padZero(d.getMinutes())}`;
+
+        const record: CloudBackupRecord = {
+          id: fileName,
+          date: dateStr,
+          timestamp: timestamp,
+          tokenCount: tokenCount,
+          size: fileSize,
+          encrypted: true,
+          deviceId: deviceId,
+          deviceName: deviceName,
+          location: stat.location,
+        };
+        records.push(record);
+      } catch (e) {
+        hilog.error(DOMAIN, TAG, `loadBackupHistoryRecords: stat error for ${fileName}=${JSON.stringify(e)}`);
+      }
+    }
+
+    records.sort((a: CloudBackupRecord, b: CloudBackupRecord) => b.timestamp - a.timestamp);
+  } catch (e) {
+    hilog.error(DOMAIN, TAG, `loadBackupHistoryRecords: error=${JSON.stringify(e)}`);
+  }
+
+  hilog.info(DOMAIN, TAG, `loadBackupHistoryRecords: returning ${records.length} records`);
+  return records;
+}
+
+

--- a/entry/src/main/ets/utils/CommonUtils.ets
+++ b/entry/src/main/ets/utils/CommonUtils.ets
@@ -1,0 +1,10 @@
+/**
+ * CommonUtils — 通用工具函数
+ *
+ * 此文件导出纯函数，可安全在 @Concurrent 装饰的 TaskPool 函数中通过 import 引入。
+ */
+
+/** 数字补零：小于 10 时前补 '0'，用于日期/时间格式化 */
+export function padZero(n: number): string {
+  return n < 10 ? `0${n}` : `${n}`;
+}

--- a/entry/src/main/ets/utils/HuaweiAccountManager.ets
+++ b/entry/src/main/ets/utils/HuaweiAccountManager.ets
@@ -8,6 +8,7 @@ const TAG = 'HuaweiAccountManager';
 const PREF_KEY_LOGGED_IN = 'huawei_logged_in';
 const PREF_KEY_USER_ACCOUNT = 'huawei_user_account';
 
+/** 华为账号授权错误码，映射到对应的 i18n 错误提示资源 */
 export enum HuaweiAccountErrorCode {
   ERROR_CODE_LOGIN_OUT = 1001502001,
   ERROR_CODE_NETWORK_ERROR = 1001502005,
@@ -38,6 +39,12 @@ export class HuaweiUserInfo {
   }
 }
 
+/**
+ * 华为账号登录管理单例。
+ * 职责：华为账号授权登录/登出、登录态持久化（Preference）、
+ * 登录态校验（getHuaweiIDState）、AppStorage 状态同步。
+ * 云备份的加密密钥与华为账号绑定，登录态是云备份功能的前置条件。
+ */
 export class HuaweiAccountManager {
   private static instance: HuaweiAccountManager;
   private prefMgr = PreferenceManager.getInstance();
@@ -53,6 +60,7 @@ export class HuaweiAccountManager {
     return HuaweiAccountManager.instance;
   }
 
+  /** 根据错误码返回对应的 i18n 资源引用，用于 UI 错误提示；ERROR_CODE_REQUEST_REFUSE 返回 null 表示静默处理 */
   static getLoginErrorResource(code: number): Resource | null {
     if (code === HuaweiAccountErrorCode.ERROR_CODE_LOGIN_OUT) {
       return $r('app.string.huawei_account_error_not_logged_in');
@@ -70,10 +78,16 @@ export class HuaweiAccountManager {
     return $r('app.string.huawei_account_login_failed');
   }
 
+  /** 判断错误码是否为用户主动取消登录 */
   static isUserCancel(code: number): boolean {
     return code === HuaweiAccountErrorCode.ERROR_CODE_USER_CANCEL;
   }
 
+  /**
+   * 初始化：从 Preference 恢复上次的登录态和用户信息，
+   * 若有保存的登录态则调用 checkAuthState 校验授权是否仍有效，
+   * 最后同步状态到 AppStorage 供 UI 绑定。
+   */
   async init(): Promise<void> {
     const savedLogin: boolean = await this.prefMgr.getValue<boolean>(PREF_KEY_LOGGED_IN) ?? false;
     const savedAccount: HuaweiUserInfo | null = await this.prefMgr.getValue<HuaweiUserInfo>(PREF_KEY_USER_ACCOUNT);
@@ -85,6 +99,10 @@ export class HuaweiAccountManager {
     this.updateAppStorage();
   }
 
+  /**
+   * 校验已保存账号的授权状态：通过 unionId 查询华为 ID 服务，
+   * 若返回非 AUTHORIZED 则标记为未登录（可能用户在其他设备解除了授权）。
+   */
   private checkAuthState(): void {
     const stateRequest: authentication.StateRequest = {
       idType: authentication.IdType.UNION_ID,
@@ -103,6 +121,7 @@ export class HuaweiAccountManager {
       });
   }
 
+  /** 获取当前登录用户信息，未登录返回 undefined */
   getUserInfo(): HuaweiUserInfo | undefined {
     if (this.userLogin) {
       return this.userAccount;
@@ -110,6 +129,11 @@ export class HuaweiAccountManager {
     return undefined;
   }
 
+  /**
+   * 华为账号登录：发起 AuthorizationWithHuaweiID 授权请求，
+   * 获取昵称、头像、unionID，更新内存/Preference/AppStorage 三层状态。
+   * @param uiContext 页面 UIContext，用于创建 AuthenticationController
+   */
   async login(uiContext: UIContext): Promise<HuaweiUserInfo> {
     const credential = await this.getAuthCredential(uiContext);
     this.userAccount = new HuaweiUserInfo(
@@ -123,6 +147,13 @@ export class HuaweiAccountManager {
     return this.userAccount;
   }
 
+  /**
+   * 构建华为账号授权请求并执行：
+   * - 请求 profile scope 获取用户基本信息
+   * - 请求 serviceauthcode 权限用于后端服务验证
+   * - forceAuthorization=true 强制弹出授权页面
+   * - 使用随机 UUID 作为 state 参数防止 CSRF 攻击
+   */
   private getAuthCredential(uiContext: UIContext): Promise<authentication.AuthorizationWithHuaweiIDCredential> {
     const authRequest = new authentication.HuaweiIDProvider().createAuthorizationWithHuaweiIDRequest();
     authRequest.scopes = ['profile'];
@@ -151,6 +182,7 @@ export class HuaweiAccountManager {
     });
   }
 
+  /** 登出：清空内存用户信息、更新 Preference 和 AppStorage（不会撤销华为 ID 授权） */
   async logout(): Promise<void> {
     this.userLogin = false;
     this.userAccount = new HuaweiUserInfo('', '', '');
@@ -158,17 +190,20 @@ export class HuaweiAccountManager {
     this.updateAppStorage();
   }
 
+  /** 账号选择器回调：用户在系统账号选择器中确认后调用，标记为已登录 */
   selectHuaweiAccountToLogin(): void {
     this.userLogin = true;
     this.updatePreference();
     this.updateAppStorage();
   }
 
+  /** 持久化登录态到 Preference：登录时保存，登出时清空用户信息 */
   private updatePreference(): void {
     this.prefMgr.setValue(PREF_KEY_LOGGED_IN, this.userLogin);
     this.prefMgr.setValue(PREF_KEY_USER_ACCOUNT, this.userLogin ? this.userAccount : null);
   }
 
+  /** 同步登录态到 AppStorage，供 UI 组件通过 AppStorageV2.connect 响应式绑定 */
   private updateAppStorage(): void {
     AppStorage.setOrCreate('huawei_is_logged_in', this.userLogin);
     AppStorage.setOrCreate('huawei_user', this.userLogin ? this.userAccount : null);

--- a/entry/src/main/ets/utils/SyncTimeHelper.ets
+++ b/entry/src/main/ets/utils/SyncTimeHelper.ets
@@ -1,0 +1,98 @@
+/**
+ * SyncTimeHelper — 云同步时间戳辅助工具
+ *
+ * CLOUD_SYNC_LAST_TIME 存储格式统一为 unix 毫秒时间戳字符串（如 "1745385600000"），
+ * UI 显示时通过 formatTimestamp() 转为可读格式（如 "2026-04-23 14:30"）。
+ *
+ * parseStoredTimestamp() 同时兼容旧版日期字符串格式（如 "2026-04-23 14:30"），
+ * 首次读取时自动向上兼容。
+ */
+import { hilog } from '@kit.PerformanceAnalysisKit';
+
+const TAG = 'SyncTimeHelper';
+const DOMAIN = 0xFF00;
+
+export class SyncTimeHelper {
+  /** 将 unix 毫秒时间戳转为 "YYYY-MM-DD HH:mm" 格式字符串，ts <= 0 返回空串 */
+  static formatTimestamp(ts: number): string {
+    if (ts <= 0) {
+      return '';
+    }
+    const d = new Date(ts);
+    return `${d.getFullYear()}-${SyncTimeHelper.padZero(d.getMonth() + 1)}-${SyncTimeHelper.padZero(d.getDate())} ${SyncTimeHelper.padZero(d.getHours())}:${SyncTimeHelper.padZero(d.getMinutes())}`;
+  }
+
+  /** 判断时间戳是否为今天 */
+  static isToday(ts: number): boolean {
+    if (ts <= 0) {
+      return false;
+    }
+    const d = new Date(ts);
+    const today = new Date();
+    return d.getFullYear() === today.getFullYear() &&
+      d.getMonth() === today.getMonth() &&
+      d.getDate() === today.getDate();
+  }
+
+  /** 获取昨天 23:59:59.999 的时间戳，用于清空备份后将 lastSyncTime 设为"已过期" */
+  static getYesterdayEndTs(): number {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    return today.getTime() - 1;
+  }
+
+  /** 判断时间戳距今是否在指定分钟数内 */
+  static isWithinMinutes(ts: number, minutes: number): boolean {
+    if (ts <= 0) {
+      return false;
+    }
+    return (Date.now() - ts) < minutes * 60000;
+  }
+
+  /** 获取今天 00:00:00.000 的时间戳 */
+  static getTodayStartTs(): number {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    return today.getTime();
+  }
+
+  /**
+   * 解析存储的时间值为 unix 毫秒时间戳。
+   * 兼容两种格式：
+   * - 新格式：纯数字字符串（如 "1745385600000"）
+   * - 旧格式：日期字符串（如 "2026-04-23 14:30"）
+   * 无法解析时返回 0。
+   */
+  static parseStoredTimestamp(value: string | number): number {
+    if (typeof value === 'number') {
+      return value as number;
+    }
+    if (!value || value.length === 0) {
+      return 0;
+    }
+    const parsed = Number(value);
+    if (!isNaN(parsed) && parsed > 0) {
+      return parsed;
+    }
+    try {
+      const parts = value.split(/[- :\s]/);
+      if (parts.length >= 5) {
+        const d = new Date(
+          parseInt(parts[0]),
+          parseInt(parts[1]) - 1,
+          parseInt(parts[2]),
+          parseInt(parts[3]),
+          parseInt(parts[4])
+        );
+        return d.getTime();
+      }
+    } catch (e) {
+      hilog.warn(DOMAIN, TAG, `parseStoredTimestamp: failed: ${(e as Error).message}`);
+    }
+    return 0;
+  }
+
+  private static padZero(n: number): string {
+    return n < 10 ? `0${n}` : `${n}`;
+  }
+}

--- a/entry/src/main/resources/base/element/string.json
+++ b/entry/src/main/resources/base/element/string.json
@@ -405,6 +405,10 @@
       "value": "Manual Backup"
     },
     {
+      "name": "data_sync_manual_des",
+      "value": "Upload all tokens to Huawei Cloud"
+    },
+    {
       "name": "data_dev_info",
       "value": "Device Info"
     },
@@ -1102,7 +1106,11 @@
     },
     {
       "name": "cloud_sync_trigger_sync",
-      "value": "Trigger Sync"
+      "value": "Sync from Cloud"
+    },
+    {
+      "name": "cloud_sync_trigger_sync_des",
+      "value": "Download the latest backup files from cloud to this device"
     },
     {
       "name": "cloud_sync_sync_state",
@@ -1239,6 +1247,10 @@
     {
       "name": "cloud_sync_device_id_hint",
       "value": "The device name and ID are based on the system-generated device identifier, which may change after factory reset or reinstalling all apps from the same developer. If the ID changes, backups from this device will be displayed under \"Other Devices\"."
+    },
+    {
+      "name": "cloud_sync_operations",
+      "value": "Operations"
     }
   ]
 }

--- a/entry/src/main/resources/en_US/element/string.json
+++ b/entry/src/main/resources/en_US/element/string.json
@@ -406,7 +406,11 @@
     },
     {
       "name": "data_sync_manual",
-      "value": "Manual Backup"
+      "value": "Backup Now"
+    },
+    {
+      "name": "data_sync_manual_des",
+      "value": "Upload all tokens to Huawei Cloud"
     },
     {
       "name": "data_dev_info",
@@ -1102,7 +1106,11 @@
     },
     {
       "name": "cloud_sync_trigger_sync",
-      "value": "Trigger Sync"
+      "value": "Sync from Cloud"
+    },
+    {
+      "name": "cloud_sync_trigger_sync_des",
+      "value": "Download the latest backup files from cloud to this device"
     },
     {
       "name": "cloud_sync_sync_state",
@@ -1239,6 +1247,10 @@
     {
       "name": "cloud_sync_device_id_hint",
       "value": "The device name and ID are based on the system-generated device identifier, which may change after factory reset or reinstalling all apps from the same developer. If the ID changes, backups from this device will be displayed under \"Other Devices\"."
+    },
+    {
+      "name": "cloud_sync_operations",
+      "value": "Operations"
     }
   ]
 }

--- a/entry/src/main/resources/zh_CN/element/string.json
+++ b/entry/src/main/resources/zh_CN/element/string.json
@@ -406,7 +406,11 @@
     },
     {
       "name": "data_sync_manual",
-      "value": "手动备份"
+      "value": "立即备份"
+    },
+    {
+      "name": "data_sync_manual_des",
+      "value": "将当前所有令牌备份到华为云"
     },
     {
       "name": "data_dev_info",
@@ -1102,7 +1106,11 @@
     },
     {
       "name": "cloud_sync_trigger_sync",
-      "value": "触发同步"
+      "value": "从云端恢复"
+    },
+    {
+      "name": "cloud_sync_trigger_sync_des",
+      "value": "将云端最新的备份文件同步到本设备"
     },
     {
       "name": "cloud_sync_sync_state",
@@ -1239,6 +1247,10 @@
     {
       "name": "cloud_sync_device_id_hint",
       "value": "设备名称和标识基于系统生成的设备标识符，恢复出厂设置或卸载同开发者所有应用后重新安装时可能会发生变化。标识变化后，本设备的备份将显示在\"其他设备\"分组中。"
+    },
+    {
+      "name": "cloud_sync_operations",
+      "value": "操作"
     }
   ]
 }

--- a/entry/src/main/resources/zh_TW/element/string.json
+++ b/entry/src/main/resources/zh_TW/element/string.json
@@ -1102,7 +1102,11 @@
     },
     {
       "name": "cloud_sync_trigger_sync",
-      "value": "觸發同步"
+      "value": "從雲端恢復"
+    },
+    {
+      "name": "cloud_sync_trigger_sync_des",
+      "value": "將雲端最新的備份檔案同步到本裝置"
     },
     {
       "name": "cloud_sync_sync_state",
@@ -1239,6 +1243,10 @@
     {
       "name": "cloud_sync_device_id_hint",
       "value": "裝置名稱和識別基於系統產生的裝置識別碼，恢復原廠設定或解除安裝同開發者所有應用後重新安裝時可能會發生變化。識別變化後，本裝置的備份將顯示在「其他裝置」分組中。"
+    },
+    {
+      "name": "cloud_sync_operations",
+      "value": "操作"
     }
   ]
 }


### PR DESCRIPTION
… timestamp migration, backup history TaskPool loading, core module comments

云同步详情页和备份历史页的I/O操作迁移至TaskPool后台线程，避免逐文件读取阻塞UI主线程。
CLOUD_SYNC_LAST_TIME存储格式从日期字符串迁移为unix毫秒时间戳，新增SyncTimeHelper工具类统一处理。 新增CloudSyncTask.ets定义@Concurrent函数，新增CommonUtils.ets提供跨线程安全导入的纯函数。 为CloudBackupCrypto、HuaweiAccountManager、ShowCloudSyncDetailsPage、ShowCloudBackupHistoryPage添加中文注释。 新增cloud_sync_operations等i18n资源，操作区SettingItem添加标题，操作按钮补充描述文本。

- Migrate I/O-heavy operations (initial sync check, backup history listing) to TaskPool worker threads
- Migrate CLOUD_SYNC_LAST_TIME from date string to unix millisecond timestamp with SyncTimeHelper
- Add CloudSyncTask.ets with @Concurrent functions (checkCloudBackupRecords, loadBackupHistoryRecords)
- Add CommonUtils.ets with padZero for safe @Concurrent import (ArkTS closure variable restriction)
- Add Chinese comments to CloudBackupCrypto, HuaweiAccountManager, ShowCloudSyncDetailsPage, ShowCloudBackupHistoryPage
- Add cloud_sync_operations i18n string, operation section title, button descriptions
- Fix triggerFileSync/triggerCloudSync login+enable dual guard
- Fix aboutToDisappear console.error -> hilog.error
- Bump versionCode to 1002032