### PR TITLE
refactor(TokenItem): 迁移 HdsListItemCard + 外观自定义全面化

### DIFF
--- a/entry/package-lock.json
+++ b/entry/package-lock.json
@@ -1,0 +1,18 @@
+{
+  "name": "entry",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "long": "^5.2.1"
+      }
+    },
+    "node_modules/long": {
+      "version": "5.2.1",
+      "resolved": "https://ohpm.openharmony.cn/ohpm/long/-/long-5.2.1.tgz",
+      "integrity": "sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A==",
+      "license": "Apache-2.0"
+    }
+  }
+}

--- a/entry/package.json
+++ b/entry/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "long": "^5.2.1"
+  }
+}

--- a/entry/src/main/ets/components/TokenItem.ets
+++ b/entry/src/main/ets/components/TokenItem.ets
@@ -19,6 +19,7 @@ import {
   TextOptions
 } from '@kit.UIDesignKit';
 import { TextModifier } from '@ohos.arkui.modifier';
+import { CommonConstants } from '../utils/CommonConstants';
 
 let current_token_hide_map: Map<string, boolean> = new Map();
 let tkStore = TokenStore.getInstance();
@@ -260,6 +261,7 @@ export struct TokenItem {
     Column() {
       HdsListItemCard({
         prefixItem: new PrefixCustomBuilder((): void => { this.TokenIconBuilder() }),
+        cardPrefixMargin: CommonConstants.TOKEN_CARD_PREFIX_MARGIN,
         textItem: {
           primaryText: {
             text: this.token_preference.app_appearance_swap_host_user_enable ? this.Config.TokenName : this.Config.TokenIssuer,
@@ -277,6 +279,7 @@ export struct TokenItem {
           } as TextOptions
         },
         suffixItem: new SuffixCustomBuilder((): void => { this.TokenCodeBuilder() }),
+        cardSuffixMargin: CommonConstants.TOKEN_CARD_SUFFIX_MARGIN,
         cardHeight: this.token_preference.app_appearance_item_height,
         cardBackgroundColor: $r('app.color.item_bg'),
         onClick: () => {

--- a/entry/src/main/ets/components/TokenItem.ets
+++ b/entry/src/main/ets/components/TokenItem.ets
@@ -12,6 +12,13 @@ import { QRCodeDialog } from '../dialogs/QRCodeDialog';
 import { AppWindowInfo } from '../entryability/EntryAbility';
 import { TokenStore } from '../utils/TokenStore';
 import { ConfigurationConstant } from '@kit.AbilityKit';
+import {
+  HdsListItemCard,
+  PrefixCustomBuilder,
+  SuffixCustomBuilder,
+  TextOptions
+} from '@kit.UIDesignKit';
+import { TextModifier } from '@ohos.arkui.modifier';
 
 let current_token_hide_map: Map<string, boolean> = new Map();
 let tkStore = TokenStore.getInstance();
@@ -162,28 +169,14 @@ export struct TokenItem {
     }
   }
 
-  build() {
-    Row({ space: 10 }) {
-      TokenIcon({ issuer: this.Config.TokenIssuer, icon_path: this.Config.TokenIconPath })
-      Column() {
-        Text(this.token_preference.app_appearance_swap_host_user_enable ? this.Config.TokenName : this.Config.TokenIssuer)
-          .textOverflow({ overflow: TextOverflow.MARQUEE })
-          .maxLines(1)
-          .fontSize(this.token_preference.app_appearance_issuer_font_size)
-          .fontWeight(this.token_preference.app_appearance_issuer_font_weight)
-          .fontColor($r('app.color.str_main'))
-        Text(this.token_preference.app_appearance_swap_host_user_enable ? this.Config.TokenIssuer : this.Config.TokenName)
-          .textOverflow({ overflow: TextOverflow.MARQUEE })
-          .maxLines(1)
-          .fontSize(this.token_preference.app_appearance_user_name_font_size)
-          .fontWeight(this.token_preference.app_appearance_user_name_font_weight)
-          .fontColor($r('app.color.str_gray'))
-      }
-      .layoutWeight(1)
-      .alignItems(HorizontalAlign.Start)
+  @Builder
+  TokenIconBuilder() {
+    TokenIcon({ issuer: this.Config.TokenIssuer, icon_path: this.Config.TokenIconPath })
+  }
 
-      Blank()
-
+  @Builder
+  TokenCodeBuilder() {
+    Column() {
       if (AppPreference.getPreference(PREF_KEYS.DEBUG_MODE_ON)) {
         Text(this.Config.RankScore.toString())
           .textAlign(TextAlign.Center)
@@ -193,91 +186,110 @@ export struct TokenItem {
       }
 
       if (this.TokenHide && this.token_preference.app_safety_hide_token_enable) {
-        Stack() {
-          Text() {
-            Span("●●●●")
-          }
-          .fontColor(Color.Gray)
-          .fontSize(this.token_preference.app_appearance_token_font_size)
+        Text() {
+          Span("●●●●")
         }
-        .onClick(() => {
-          this.TokenHide = !this.TokenHide;
-          current_token_hide_map[this.Config.TokenUUID] = false;
-        })
-
+        .fontColor(Color.Gray)
+        .fontSize(this.token_preference.app_appearance_token_font_size)
       } else {
-        Column() {
-          Text(this.TokenNumber)
-            .textAlign(TextAlign.End)
-            .textOverflow({ overflow: TextOverflow.MARQUEE })
-            .maxLines(1)
-            .fontColor(this.TokenLeftPeriod <= this.token_color_change_threshold && this.Config.TokenType !== otpType.HOTP ?
-              this.token_color_expiring : this.token_color_normal)
-            .fontSize(this.token_preference.app_appearance_token_font_size)
-            .fontWeight(this.token_preference.app_appearance_token_font_weight)
-            .gesture(
-              LongPressGesture()
-                .onAction(() => {
-                  copyText(this.TokenNumber, `token ${this.TokenNumber} `+ this.getUIContext().getHostContext()?.resourceManager.getStringSync($r('app.string.token_copied').id));
-                })
-            )
-          if (this.Config.TokenType == otpType.HOTP) {
-            Text(this.TokenCounter + (this.token_preference.app_appearance_show_next_token_enable ? ":" + this.TokenNumberNext : ""))
+        Row({ space: 4 }) {
+          Column() {
+            Text(this.TokenNumber)
               .textAlign(TextAlign.End)
               .textOverflow({ overflow: TextOverflow.MARQUEE })
               .maxLines(1)
-              .fontColor($r('app.color.str_gray'))
-              .fontSize(10)
-          } else if (this.token_preference.app_appearance_show_next_token_enable) {
-            Text(this.TokenNumberNext)
-              .textAlign(TextAlign.End)
-              .textOverflow({ overflow: TextOverflow.MARQUEE })
-              .maxLines(1)
-              .fontColor($r('app.color.str_gray'))
-              .fontSize(10)
+              .fontColor(this.TokenLeftPeriod <= this.token_color_change_threshold && this.Config.TokenType !== otpType.HOTP ?
+                this.token_color_expiring : this.token_color_normal)
+              .fontSize(this.token_preference.app_appearance_token_font_size)
+              .fontWeight(this.token_preference.app_appearance_token_font_weight)
+              .gesture(
+                LongPressGesture()
+                  .onAction(() => {
+                    copyText(this.TokenNumber, `token ${this.TokenNumber} `+ this.getUIContext().getHostContext()?.resourceManager.getStringSync($r('app.string.token_copied').id));
+                  })
+              )
+            if (this.Config.TokenType == otpType.HOTP) {
+              Text(this.TokenCounter + (this.token_preference.app_appearance_show_next_token_enable ? ":" + this.TokenNumberNext : ""))
+                .textAlign(TextAlign.End)
+                .textOverflow({ overflow: TextOverflow.MARQUEE })
+                .maxLines(1)
+                .fontColor($r('app.color.str_gray'))
+                .fontSize(10)
+            } else if (this.token_preference.app_appearance_show_next_token_enable) {
+              Text(this.TokenNumberNext)
+                .textAlign(TextAlign.End)
+                .textOverflow({ overflow: TextOverflow.MARQUEE })
+                .maxLines(1)
+                .fontColor($r('app.color.str_gray'))
+                .fontSize(10)
+            }
           }
-        }
-        .onClick(() => {
-          if (this.token_preference.app_safety_hide_token_enable) {
-            this.TokenHide = !this.TokenHide;
-            current_token_hide_map[this.Config.TokenUUID] = true;
-          }
-        })
 
-        if (this.Config.TokenType == otpType.HOTP) {
-          SymbolGlyph($r('sys.symbol.lock_filled_arrow_counterclockwise'))
-            .fontColor([this.hotp_next_btn_color])
-            .fontSize(40)
-            .fontWeight(FontWeight.Medium)
-            .symbolEffect(new BounceSymbolEffect(EffectScope.WHOLE, EffectDirection.UP),
-              this.btn_hotp_clicked)
-            .onClick(() => {
-              this.btn_hotp_clicked++;
-              this.Config.TokenCounter++;
-              this.Update(this.Config)
-              this.updateHOTPToken();
-            })
-        } else {
-          Stack() {
-            Text(this.TokenLeftPeriod.toString())
-            Progress({ value: this.TokenLeftPeriod, total: this.Config.TokenPeriod, type: ProgressType.Ring })
-              .style({ strokeWidth: 8 })
-              .width(40)
-              .height(40)
-              .color(this.TokenLeftPeriod <= this.token_color_change_threshold ?
-                this.token_progress_color_near_next :
-                this.token_progress_color_normal)
+          if (this.Config.TokenType == otpType.HOTP) {
+            SymbolGlyph($r('sys.symbol.lock_filled_arrow_counterclockwise'))
+              .fontColor([this.hotp_next_btn_color])
+              .fontSize(40)
+              .fontWeight(FontWeight.Medium)
+              .symbolEffect(new BounceSymbolEffect(EffectScope.WHOLE, EffectDirection.UP),
+                this.btn_hotp_clicked)
+              .onClick(() => {
+                this.btn_hotp_clicked++;
+                this.Config.TokenCounter++;
+                this.Update(this.Config)
+                this.updateHOTPToken();
+              })
+          } else {
+            Stack() {
+              Text(this.TokenLeftPeriod.toString())
+              Progress({ value: this.TokenLeftPeriod, total: this.Config.TokenPeriod, type: ProgressType.Ring })
+                .style({ strokeWidth: 8 })
+                .width(40)
+                .height(40)
+                .color(this.TokenLeftPeriod <= this.token_color_change_threshold ?
+                  this.token_progress_color_near_next :
+                  this.token_progress_color_normal)
+            }
           }
         }
       }
     }
-    .borderRadius(10)
-    .shadow({ radius: 10, color: $r('app.color.shadow'), offsetX: 10, offsetY: 10 })
-    .padding(10)
-    .justifyContent(FlexAlign.SpaceBetween)
-    .width('100%')
-    .height(this.token_preference.app_appearance_item_height)
-    .backgroundColor($r("app.color.item_bg"))
+    .alignItems(HorizontalAlign.End)
+  }
+
+  build() {
+    Column() {
+      HdsListItemCard({
+        prefixItem: new PrefixCustomBuilder((): void => { this.TokenIconBuilder() }),
+        textItem: {
+          primaryText: {
+            text: this.token_preference.app_appearance_swap_host_user_enable ? this.Config.TokenName : this.Config.TokenIssuer,
+            modifier: new TextModifier()
+              .fontSize(this.token_preference.app_appearance_issuer_font_size)
+              .fontWeight(this.token_preference.app_appearance_issuer_font_weight)
+              .fontColor($r('app.color.str_main'))
+          } as TextOptions,
+          secondaryText: {
+            text: this.token_preference.app_appearance_swap_host_user_enable ? this.Config.TokenIssuer : this.Config.TokenName,
+            modifier: new TextModifier()
+              .fontSize(this.token_preference.app_appearance_user_name_font_size)
+              .fontWeight(this.token_preference.app_appearance_user_name_font_weight)
+              .fontColor($r('app.color.str_gray'))
+          } as TextOptions
+        },
+        suffixItem: new SuffixCustomBuilder((): void => { this.TokenCodeBuilder() }),
+        cardHeight: this.token_preference.app_appearance_item_height,
+        cardBackgroundColor: $r('app.color.item_bg'),
+        onClick: () => {
+          if (this.TokenHide && this.token_preference.app_safety_hide_token_enable) {
+            this.TokenHide = !this.TokenHide;
+            current_token_hide_map[this.Config.TokenUUID] = false;
+          } else if (this.token_preference.app_safety_hide_token_enable) {
+            this.TokenHide = !this.TokenHide;
+            current_token_hide_map[this.Config.TokenUUID] = true;
+          }
+        }
+      })
+    }
     .bindContextMenu(this.TokenRightCtxMenu, ResponseType.RightClick, { enableArrow: true })
   }
 

--- a/entry/src/main/ets/components/TokenItem.ets
+++ b/entry/src/main/ets/components/TokenItem.ets
@@ -173,6 +173,7 @@ export struct TokenItem {
   @Builder
   TokenIconBuilder() {
     TokenIcon({ issuer: this.Config.TokenIssuer, icon_path: this.Config.TokenIconPath })
+      .padding({ left: $r('sys.float.ohos_id_text_overlay_menu_button_padding_left'), right: $r('sys.float.ohos_id_text_overlay_menu_button_padding_right') })
   }
 
   @Builder
@@ -255,6 +256,7 @@ export struct TokenItem {
       }
     }
     .alignItems(HorizontalAlign.End)
+    .padding({ left: $r('sys.float.ohos_id_text_overlay_menu_button_padding_left'), right: $r('sys.float.ohos_id_text_overlay_menu_button_padding_right') })
   }
 
   build() {
@@ -268,6 +270,8 @@ export struct TokenItem {
               .fontSize(this.token_preference.app_appearance_issuer_font_size)
               .fontWeight(this.token_preference.app_appearance_issuer_font_weight)
               .fontColor($r('app.color.str_main'))
+              .textOverflow({ overflow: TextOverflow.MARQUEE })
+              .maxLines(1)
           } as TextOptions,
           secondaryText: {
             text: this.token_preference.app_appearance_swap_host_user_enable ? this.Config.TokenIssuer : this.Config.TokenName,
@@ -275,10 +279,14 @@ export struct TokenItem {
               .fontSize(this.token_preference.app_appearance_user_name_font_size)
               .fontWeight(this.token_preference.app_appearance_user_name_font_weight)
               .fontColor($r('app.color.str_gray'))
+              .textOverflow({ overflow: TextOverflow.MARQUEE })
+              .maxLines(1)
           } as TextOptions
         },
         suffixItem: new SuffixCustomBuilder((): void => { this.TokenCodeBuilder() }),
         cardHeight: this.token_preference.app_appearance_item_height,
+        cardPrefixMargin: this.token_preference.app_appearance_token_list_item_prefix_padding,
+        cardSuffixMargin: this.token_preference.app_appearance_token_list_item_suffix_padding,
         cardBackgroundColor: $r('app.color.item_bg'),
         onClick: () => {
           if (this.TokenHide && this.token_preference.app_safety_hide_token_enable) {

--- a/entry/src/main/ets/components/TokenItem.ets
+++ b/entry/src/main/ets/components/TokenItem.ets
@@ -15,10 +15,8 @@ import { ConfigurationConstant } from '@kit.AbilityKit';
 import {
   HdsListItemCard,
   PrefixCustomBuilder,
-  SuffixCustomBuilder,
-  TextOptions
+  SuffixCustomBuilder
 } from '@kit.UIDesignKit';
-import { TextModifier } from '@ohos.arkui.modifier';
 import { CommonConstants } from '../utils/CommonConstants';
 
 let current_token_hide_map: Map<string, boolean> = new Map();
@@ -118,6 +116,25 @@ export struct TokenItem {
           offset: 1
         },
       ]);
+  }
+
+  @Builder
+  TextContentBuilder() {
+    Column() {
+      Text(this.token_preference.app_appearance_swap_host_user_enable ? this.Config.TokenName : this.Config.TokenIssuer)
+        .fontSize(this.token_preference.app_appearance_issuer_font_size)
+        .fontWeight(this.token_preference.app_appearance_issuer_font_weight)
+        .fontColor($r('app.color.str_main'))
+        .textOverflow({ overflow: TextOverflow.MARQUEE })
+        .maxLines(1)
+      Text(this.token_preference.app_appearance_swap_host_user_enable ? this.Config.TokenIssuer : this.Config.TokenName)
+        .fontSize(this.token_preference.app_appearance_user_name_font_size)
+        .fontWeight(this.token_preference.app_appearance_user_name_font_weight)
+        .fontColor($r('app.color.str_gray'))
+        .textOverflow({ overflow: TextOverflow.MARQUEE })
+        .maxLines(1)
+    }
+    .alignItems(HorizontalAlign.Start)
   }
 
   aboutToAppear(): void {
@@ -264,24 +281,7 @@ export struct TokenItem {
       HdsListItemCard({
         prefixItem: new PrefixCustomBuilder((): void => { this.TokenIconBuilder() }),
         textItem: {
-          primaryText: {
-            text: this.token_preference.app_appearance_swap_host_user_enable ? this.Config.TokenName : this.Config.TokenIssuer,
-            modifier: new TextModifier()
-              .fontSize(this.token_preference.app_appearance_issuer_font_size)
-              .fontWeight(this.token_preference.app_appearance_issuer_font_weight)
-              .fontColor($r('app.color.str_main'))
-              .textOverflow({ overflow: TextOverflow.MARQUEE })
-              .maxLines(1)
-          } as TextOptions,
-          secondaryText: {
-            text: this.token_preference.app_appearance_swap_host_user_enable ? this.Config.TokenIssuer : this.Config.TokenName,
-            modifier: new TextModifier()
-              .fontSize(this.token_preference.app_appearance_user_name_font_size)
-              .fontWeight(this.token_preference.app_appearance_user_name_font_weight)
-              .fontColor($r('app.color.str_gray'))
-              .textOverflow({ overflow: TextOverflow.MARQUEE })
-              .maxLines(1)
-          } as TextOptions
+          customBuilder: (): void => { this.TextContentBuilder() }
         },
         suffixItem: new SuffixCustomBuilder((): void => { this.TokenCodeBuilder() }),
         cardHeight: this.token_preference.app_appearance_item_height,

--- a/entry/src/main/ets/components/TokenItem.ets
+++ b/entry/src/main/ets/components/TokenItem.ets
@@ -261,7 +261,6 @@ export struct TokenItem {
     Column() {
       HdsListItemCard({
         prefixItem: new PrefixCustomBuilder((): void => { this.TokenIconBuilder() }),
-        cardPrefixMargin: CommonConstants.TOKEN_CARD_PREFIX_MARGIN,
         textItem: {
           primaryText: {
             text: this.token_preference.app_appearance_swap_host_user_enable ? this.Config.TokenName : this.Config.TokenIssuer,
@@ -279,7 +278,6 @@ export struct TokenItem {
           } as TextOptions
         },
         suffixItem: new SuffixCustomBuilder((): void => { this.TokenCodeBuilder() }),
-        cardSuffixMargin: CommonConstants.TOKEN_CARD_SUFFIX_MARGIN,
         cardHeight: this.token_preference.app_appearance_item_height,
         cardBackgroundColor: $r('app.color.item_bg'),
         onClick: () => {

--- a/entry/src/main/ets/dialogs/SelectIconDialog.ets
+++ b/entry/src/main/ets/dialogs/SelectIconDialog.ets
@@ -1,4 +1,5 @@
 import { TokenIcon } from "../components/TokenIcon";
+import { AppPreference, PREF_KEYS } from "../utils/AppPreference";
 import { CropModel, CropView } from "../components/ImageCropView";
 import { getImageDimensions, savePixelMapToFile, copyFileToDir } from "../utils/PhotoPickerUtils";
 import { showSelectFilePicker } from "../utils/FileUtils";
@@ -282,7 +283,7 @@ export struct SelectIconDialog {
       .lanes({ minLength: 50, maxLength: 50 })
       .width('100%')
       .height('100%')
-      .chainAnimation(true)
+      .chainAnimation(AppPreference.getPreference(PREF_KEYS.APPEARANCE_CHAIN_ANIMATION_ENABLE) as boolean)
       .scrollBar(BarState.Off)
       .edgeEffect(EdgeEffect.Spring, { alwaysEnabled: true })
       .layoutWeight(1)

--- a/entry/src/main/ets/pages/AppearancePage.ets
+++ b/entry/src/main/ets/pages/AppearancePage.ets
@@ -194,8 +194,15 @@ export struct AppearancePage {
                       step: 1
                     },
                     {
-                      name: $r('app.string.token_list_item_horizontal_padding'),
-                      default: this.token_preference.app_appearance_token_list_item_horizontal_padding,
+                      name: $r('app.string.token_list_item_prefix_padding'),
+                      default: this.token_preference.app_appearance_token_list_item_prefix_padding,
+                      min: 0,
+                      max: 30,
+                      step: 1
+                    },
+                    {
+                      name: $r('app.string.token_list_item_suffix_padding'),
+                      default: this.token_preference.app_appearance_token_list_item_suffix_padding,
                       min: 0,
                       max: 30,
                       step: 1
@@ -235,8 +242,13 @@ export struct AppearancePage {
                         break;
                       }
                       case 6: {
-                        AppPreference.setPreference(PREF_KEYS.APPEARANCE_TOKEN_LIST_ITEM_HORIZONTAL_PADDING, value);
-                        this.token_preference.app_appearance_token_list_item_horizontal_padding = value;
+                        AppPreference.setPreference(PREF_KEYS.APPEARANCE_TOKEN_LIST_ITEM_PREFIX_PADDING, value);
+                        this.token_preference.app_appearance_token_list_item_prefix_padding = value;
+                        break;
+                      }
+                      case 7: {
+                        AppPreference.setPreference(PREF_KEYS.APPEARANCE_TOKEN_LIST_ITEM_SUFFIX_PADDING, value);
+                        this.token_preference.app_appearance_token_list_item_suffix_padding = value;
                         break;
                       }
                     }

--- a/entry/src/main/ets/pages/AppearancePage.ets
+++ b/entry/src/main/ets/pages/AppearancePage.ets
@@ -193,6 +193,13 @@ export struct AppearancePage {
                       max: Math.round(this.token_preference.app_appearance_logo_background_size / 2),
                       step: 1
                     },
+                    {
+                      name: $r('app.string.token_list_item_horizontal_padding'),
+                      default: this.token_preference.app_appearance_token_list_item_horizontal_padding,
+                      min: 0,
+                      max: 30,
+                      step: 1
+                    },
                   ],
                   description: $r('app.string.token_item_slider_desc'),
                   onChange: (index, value) => {
@@ -225,6 +232,11 @@ export struct AppearancePage {
                       case 5: {
                         AppPreference.setPreference(PREF_KEYS.APPEARANCE_LOGO_BACKGROUND_RADIUS, value);
                         this.token_preference.app_appearance_logo_background_radius = value;
+                        break;
+                      }
+                      case 6: {
+                        AppPreference.setPreference(PREF_KEYS.APPEARANCE_TOKEN_LIST_ITEM_HORIZONTAL_PADDING, value);
+                        this.token_preference.app_appearance_token_list_item_horizontal_padding = value;
                         break;
                       }
                     }

--- a/entry/src/main/ets/pages/AppearancePage.ets
+++ b/entry/src/main/ets/pages/AppearancePage.ets
@@ -54,7 +54,6 @@ export struct AppearancePage {
                   }
                 })
               }
-              .padding({ left: 10, right: 10 })
 
               ListItem() {
                 TokenItem({
@@ -63,7 +62,6 @@ export struct AppearancePage {
                   }
                 })
               }
-              .padding({ left: 10, right: 10 })
             }
 
             ListItemGroup() {

--- a/entry/src/main/ets/pages/AppearancePage.ets
+++ b/entry/src/main/ets/pages/AppearancePage.ets
@@ -116,6 +116,19 @@ export struct AppearancePage {
 
                 SubItemDivider()
 
+                SubItemToggle({
+                  icon: $r('sys.symbol.rectangle_stack'),
+                  title: $r('app.string.chain_animation'),
+                  isOn: this.token_preference.app_appearance_chain_animation_enable,
+                  description: $r('app.string.chain_animation_des'),
+                  onChange: (IsOn: boolean) => {
+                    AppPreference.setPreference(PREF_KEYS.APPEARANCE_CHAIN_ANIMATION_ENABLE, IsOn);
+                    this.token_preference.app_appearance_chain_animation_enable = IsOn;
+                  }
+                })
+
+                SubItemDivider()
+
                 SubItemSlider({
                   icon: $r('sys.symbol.slider_horizontal_2'),
                   title: $r('app.string.token_item_function_slider'),
@@ -503,7 +516,7 @@ export struct AppearancePage {
               .height(this.window.AvoidBottomHeight + 56) // 56: navigation_height
           }
           .layoutWeight(1)
-          .chainAnimation(true)
+          .chainAnimation(this.token_preference.app_appearance_chain_animation_enable)
           .edgeEffect(EdgeEffect.Spring, { alwaysEnabled: true })
           .scrollBar(BarState.Off)
 

--- a/entry/src/main/ets/pages/Index.ets
+++ b/entry/src/main/ets/pages/Index.ets
@@ -1207,7 +1207,7 @@ struct Index {
         right: $r('sys.float.padding_level8'),
       })
     }
-    .chainAnimation(true)
+    .chainAnimation(this.token_preference.app_appearance_chain_animation_enable)
     .width('100%')
     .height('100%')
     .scrollBar(BarState.Off)

--- a/entry/src/main/ets/pages/ShowCloudBackupHistoryPage.ets
+++ b/entry/src/main/ets/pages/ShowCloudBackupHistoryPage.ets
@@ -138,7 +138,7 @@ export struct ShowCloudBackupHistoryPage {
                       }, (record: CloudBackupRecord) => record.id)
                     }
                   }
-                  .chainAnimation(true)
+                  .chainAnimation(AppPreference.getPreference(PREF_KEYS.APPEARANCE_CHAIN_ANIMATION_ENABLE) as boolean)
                   .edgeEffect(EdgeEffect.Spring, { alwaysEnabled: true })
                   .scrollBar(BarState.Off)
                   .backgroundColor($r('app.color.window_background'))

--- a/entry/src/main/ets/pages/ShowCloudSyncDetailsPage.ets
+++ b/entry/src/main/ets/pages/ShowCloudSyncDetailsPage.ets
@@ -317,7 +317,7 @@ export struct ShowCloudSyncDetailsPage {
                 ListItem()
                   .height(CommonConstants.AVOID_TOP_BASE_HEIGHT)
               }
-              .chainAnimation(true)
+              .chainAnimation(AppPreference.getPreference(PREF_KEYS.APPEARANCE_CHAIN_ANIMATION_ENABLE) as boolean)
               .edgeEffect(EdgeEffect.Spring, { alwaysEnabled: true })
               .scrollBar(BarState.Off)
               .backgroundColor($r('app.color.window_background'))

--- a/entry/src/main/ets/pages/ShowDataSyncDetailsPage.ets
+++ b/entry/src/main/ets/pages/ShowDataSyncDetailsPage.ets
@@ -135,7 +135,7 @@ export struct ShowDataSyncDetailsPage {
                 .padding({ left: 10, right: 10 })
 
               }
-              .chainAnimation(true)
+              .chainAnimation(AppPreference.getPreference(PREF_KEYS.APPEARANCE_CHAIN_ANIMATION_ENABLE) as boolean)
               .edgeEffect(EdgeEffect.Spring, { alwaysEnabled: true })
               .scrollBar(BarState.Off)
               .backgroundColor($r('app.color.window_background'))

--- a/entry/src/main/ets/pages/TokenListPage.ets
+++ b/entry/src/main/ets/pages/TokenListPage.ets
@@ -219,7 +219,7 @@ export struct TokenListPage {
         .layoutWeight(1)
         .width('100%')
         .height('100%')
-        .chainAnimation(true)
+        .chainAnimation(this.token_preference.app_appearance_chain_animation_enable)
         .scrollBar(BarState.Off)
         .edgeEffect(EdgeEffect.Spring, { alwaysEnabled: true })
       }

--- a/entry/src/main/ets/pages/TokenListPage.ets
+++ b/entry/src/main/ets/pages/TokenListPage.ets
@@ -215,7 +215,8 @@ export struct TokenListPage {
           .selectable(false)
         }
         .alignListItem(ListItemAlign.Center)
-        .lanes({minLength: 400, maxLength: this.token_preference.app_appearance_item_max_width})
+        .lanes(1)
+        .constraintSize({ maxWidth: this.token_preference.app_appearance_item_max_width })
         .layoutWeight(1)
         .width('100%')
         .height('100%')
@@ -224,6 +225,7 @@ export struct TokenListPage {
         .edgeEffect(EdgeEffect.Spring, { alwaysEnabled: true })
       }
     }
+    .alignItems(HorizontalAlign.Center)
   }
 
   showQRCodeDialog(conf: TokenConfig): void {

--- a/entry/src/main/ets/pages/TokenListPage.ets
+++ b/entry/src/main/ets/pages/TokenListPage.ets
@@ -189,7 +189,7 @@ export struct TokenListPage {
                 })
 
             }
-            .padding({ left: 10, right: 10 })
+            .padding({ left: CommonConstants.TOKEN_LIST_ITEM_HORIZONTAL_PADDING, right: CommonConstants.TOKEN_LIST_ITEM_HORIZONTAL_PADDING })
             .swipeAction({
               end: {
                 builder: () => {

--- a/entry/src/main/ets/pages/TokenListPage.ets
+++ b/entry/src/main/ets/pages/TokenListPage.ets
@@ -189,7 +189,6 @@ export struct TokenListPage {
                 })
 
             }
-            .padding({ left: this.token_preference.app_appearance_token_list_item_horizontal_padding, right: this.token_preference.app_appearance_token_list_item_horizontal_padding })
             .swipeAction({
               end: {
                 builder: () => {

--- a/entry/src/main/ets/pages/TokenListPage.ets
+++ b/entry/src/main/ets/pages/TokenListPage.ets
@@ -191,14 +191,9 @@ export struct TokenListPage {
             }
             .padding({ left: 10, right: 10 })
             .swipeAction({
-              start: {
-                builder: () => {
-                  this.TokenItemStart(token)
-                }
-              },
               end: {
                 builder: () => {
-                  this.TokenItemEnd(token)
+                  this.TokenItemSwipeEnd(token)
                 },
               }
             })
@@ -231,8 +226,18 @@ export struct TokenListPage {
     }
   }
 
+  showQRCodeDialog(conf: TokenConfig): void {
+    this.dialog_qrcode = new CustomDialogController({
+      builder: QRCodeDialog({
+        content: convertToken2URI(conf),
+        winSize: this.appWindowSize
+      })
+    });
+    this.dialog_qrcode.open();
+  }
+
   @Builder
-  TokenItemStart(conf: TokenConfig) {
+  TokenItemSwipeEnd(conf: TokenConfig) {
     Row({ space: 10 }) {
       Button({ type: ButtonType.Circle }) {
         Text() {
@@ -245,52 +250,7 @@ export struct TokenListPage {
       .backgroundColor(Color.Orange)
       .padding(10)
       .onClick(() => {
-        this.dialog_qrcode = new CustomDialogController({
-          builder: QRCodeDialog({
-            content: convertToken2URI(conf),
-            winSize: this.appWindowSize
-          })
-        });
-        this.dialog_qrcode.open();
-      })
-    }
-    .margin({ right: 10 })
-    .width(50)
-  }
-
-  @Builder
-  TokenItemEnd(conf: TokenConfig) {
-    Row({ space: 10 }) {
-      Button({ type: ButtonType.Circle }) {
-        Text() {
-          SymbolSpan($r('sys.symbol.trash_fill'))
-            .fontSize(30)
-            .fontWeight(FontWeight.Medium)
-            .fontColor([Color.White])
-        }
-      }
-      .backgroundColor(Color.Red)
-      .padding(10)
-      .onClick(async () => {
-        this.getUIContext().showAlertDialog({
-          message: $r('app.string.alert_remove_confirm_msg', conf.TokenName),
-          autoCancel: true,
-          alignment: DialogAlignment.Center,
-          primaryButton: {
-            defaultFocus: false,
-            value: $r('app.string.dialog_btn_cancel'),
-            action: () => {
-              return
-            }
-          },
-          secondaryButton: {
-            value: $r('app.string.dialog_btn_confirm'),
-            fontColor: Color.Red,
-            action: async () => {
-              tkStore.deleteToken(conf.TokenUUID);
-            }
-          }
-        })
+        this.showQRCodeDialog(conf);
       })
 
       if (this.TabBarVisible) {
@@ -339,6 +299,38 @@ export struct TokenListPage {
           }
         })
       }
+
+      Button({ type: ButtonType.Circle }) {
+        Text() {
+          SymbolSpan($r('sys.symbol.trash_fill'))
+            .fontSize(30)
+            .fontWeight(FontWeight.Medium)
+            .fontColor([Color.White])
+        }
+      }
+      .backgroundColor(Color.Red)
+      .padding(10)
+      .onClick(async () => {
+        AlertDialog.show({
+          message: $r('app.string.alert_remove_confirm_msg', conf.TokenName),
+          autoCancel: true,
+          alignment: DialogAlignment.Center,
+          primaryButton: {
+            defaultFocus: false,
+            value: $r('app.string.dialog_btn_cancel'),
+            action: () => {
+              return
+            }
+          },
+          secondaryButton: {
+            value: $r('app.string.dialog_btn_confirm'),
+            fontColor: Color.Red,
+            action: async () => {
+              tkStore.deleteToken(conf.TokenUUID);
+            }
+          }
+        })
+      })
     }
     .margin({ left: 10 })
   }

--- a/entry/src/main/ets/pages/TokenListPage.ets
+++ b/entry/src/main/ets/pages/TokenListPage.ets
@@ -224,8 +224,8 @@ export struct TokenListPage {
         .scrollBar(BarState.Off)
         .edgeEffect(EdgeEffect.Spring, { alwaysEnabled: true })
       }
+      .alignItems(HorizontalAlign.Center)
     }
-    .alignItems(HorizontalAlign.Center)
   }
 
   showQRCodeDialog(conf: TokenConfig): void {

--- a/entry/src/main/ets/pages/TokenListPage.ets
+++ b/entry/src/main/ets/pages/TokenListPage.ets
@@ -189,7 +189,7 @@ export struct TokenListPage {
                 })
 
             }
-            .padding({ left: CommonConstants.TOKEN_LIST_ITEM_HORIZONTAL_PADDING, right: CommonConstants.TOKEN_LIST_ITEM_HORIZONTAL_PADDING })
+            .padding({ left: this.token_preference.app_appearance_token_list_item_horizontal_padding, right: this.token_preference.app_appearance_token_list_item_horizontal_padding })
             .swipeAction({
               end: {
                 builder: () => {

--- a/entry/src/main/ets/pages/setting/SettingPage.ets
+++ b/entry/src/main/ets/pages/setting/SettingPage.ets
@@ -611,7 +611,7 @@ export struct SettingPage {
             }
           }
         }
-        .chainAnimation(true)
+        .chainAnimation(this.token_preference.app_appearance_chain_animation_enable)
         .edgeEffect(EdgeEffect.Spring, { alwaysEnabled: true })
         .scrollBar(BarState.Off)
       }

--- a/entry/src/main/ets/utils/AppPreference.ets
+++ b/entry/src/main/ets/utils/AppPreference.ets
@@ -280,8 +280,8 @@ export class TokenPreference {
   @Trace app_appearance_user_name_font_size = 10;
   @Trace app_appearance_user_name_font_weight = 400;
   @Trace app_appearance_item_max_width = 800;
-  @Trace app_appearance_token_list_item_prefix_padding = 6;
-  @Trace app_appearance_token_list_item_suffix_padding = 6;
+  @Trace app_appearance_token_list_item_prefix_padding = 10;
+  @Trace app_appearance_token_list_item_suffix_padding = 10;
 }
 
 /**
@@ -404,8 +404,8 @@ export class AppPreference {
     [PREF_KEYS.APPEARANCE_USER_NAME_FONT_SIZE, 10],
     [PREF_KEYS.APPEARANCE_USER_NAME_FONT_WEIGHT, 400],
     [PREF_KEYS.APPEARANCE_ITEM_MAX_WIDTH, 800],
-    [PREF_KEYS.APPEARANCE_TOKEN_LIST_ITEM_PREFIX_PADDING, 6],
-    [PREF_KEYS.APPEARANCE_TOKEN_LIST_ITEM_SUFFIX_PADDING, 6],
+    [PREF_KEYS.APPEARANCE_TOKEN_LIST_ITEM_PREFIX_PADDING, 10],
+    [PREF_KEYS.APPEARANCE_TOKEN_LIST_ITEM_SUFFIX_PADDING, 10],
     // 外观-顶部模糊类型
     [PREF_KEYS.APPEARANCE_TOP_EFFECT_TYPE, SettingTopEffectType.IMMERSIVE_GRADIENT_BLUR],
     [PREF_KEYS.APPEARANCE_HUAWEI_CLOUD_SYNC_ENABLE, false],

--- a/entry/src/main/ets/utils/AppPreference.ets
+++ b/entry/src/main/ets/utils/AppPreference.ets
@@ -148,6 +148,8 @@ export enum PREF_KEYS {
   APPEARANCE_TOKEN_LIST_ITEM_PREFIX_PADDING = 'app_appearance_token_list_item_prefix_padding',
   /** Token列表项目右内边距（suffix） */
   APPEARANCE_TOKEN_LIST_ITEM_SUFFIX_PADDING = 'app_appearance_token_list_item_suffix_padding',
+  /** 外观列表链式动画开关 */
+  APPEARANCE_CHAIN_ANIMATION_ENABLE = 'app_appearance_chain_animation_enable',
   /** 快速扫描URI */
   WANT_URI = 'app_want_uri',
   /** 是否启用华为云备份 */
@@ -282,6 +284,7 @@ export class TokenPreference {
   @Trace app_appearance_item_max_width = 800;
   @Trace app_appearance_token_list_item_prefix_padding = 10;
   @Trace app_appearance_token_list_item_suffix_padding = 10;
+  @Trace app_appearance_chain_animation_enable = true;
 }
 
 /**
@@ -406,6 +409,7 @@ export class AppPreference {
     [PREF_KEYS.APPEARANCE_ITEM_MAX_WIDTH, 800],
     [PREF_KEYS.APPEARANCE_TOKEN_LIST_ITEM_PREFIX_PADDING, 10],
     [PREF_KEYS.APPEARANCE_TOKEN_LIST_ITEM_SUFFIX_PADDING, 10],
+    [PREF_KEYS.APPEARANCE_CHAIN_ANIMATION_ENABLE, true],
     // 外观-顶部模糊类型
     [PREF_KEYS.APPEARANCE_TOP_EFFECT_TYPE, SettingTopEffectType.IMMERSIVE_GRADIENT_BLUR],
     [PREF_KEYS.APPEARANCE_HUAWEI_CLOUD_SYNC_ENABLE, false],
@@ -535,6 +539,8 @@ export class AppPreference {
       AppPreference.getPreference(PREF_KEYS.APPEARANCE_TOKEN_LIST_ITEM_PREFIX_PADDING) as number;
     token_appearance.app_appearance_token_list_item_suffix_padding =
       AppPreference.getPreference(PREF_KEYS.APPEARANCE_TOKEN_LIST_ITEM_SUFFIX_PADDING) as number;
+    token_appearance.app_appearance_chain_animation_enable =
+      AppPreference.getPreference(PREF_KEYS.APPEARANCE_CHAIN_ANIMATION_ENABLE) as boolean;
   }
 
   /**

--- a/entry/src/main/ets/utils/AppPreference.ets
+++ b/entry/src/main/ets/utils/AppPreference.ets
@@ -144,8 +144,10 @@ export enum PREF_KEYS {
   APPEARANCE_USER_NAME_FONT_WEIGHT = 'app_appearance_user_name_font_weight',
   /** Token项目最大宽度 */
   APPEARANCE_ITEM_MAX_WIDTH = 'app_appearance_item_max_width',
-  /** Token列表项目水平内边距 */
-  APPEARANCE_TOKEN_LIST_ITEM_HORIZONTAL_PADDING = 'app_appearance_token_list_item_horizontal_padding',
+  /** Token列表项目左内边距（prefix） */
+  APPEARANCE_TOKEN_LIST_ITEM_PREFIX_PADDING = 'app_appearance_token_list_item_prefix_padding',
+  /** Token列表项目右内边距（suffix） */
+  APPEARANCE_TOKEN_LIST_ITEM_SUFFIX_PADDING = 'app_appearance_token_list_item_suffix_padding',
   /** 快速扫描URI */
   WANT_URI = 'app_want_uri',
   /** 是否启用华为云备份 */
@@ -278,7 +280,8 @@ export class TokenPreference {
   @Trace app_appearance_user_name_font_size = 10;
   @Trace app_appearance_user_name_font_weight = 400;
   @Trace app_appearance_item_max_width = 800;
-  @Trace app_appearance_token_list_item_horizontal_padding = 6;
+  @Trace app_appearance_token_list_item_prefix_padding = 6;
+  @Trace app_appearance_token_list_item_suffix_padding = 6;
 }
 
 /**
@@ -401,7 +404,8 @@ export class AppPreference {
     [PREF_KEYS.APPEARANCE_USER_NAME_FONT_SIZE, 10],
     [PREF_KEYS.APPEARANCE_USER_NAME_FONT_WEIGHT, 400],
     [PREF_KEYS.APPEARANCE_ITEM_MAX_WIDTH, 800],
-    [PREF_KEYS.APPEARANCE_TOKEN_LIST_ITEM_HORIZONTAL_PADDING, 6],
+    [PREF_KEYS.APPEARANCE_TOKEN_LIST_ITEM_PREFIX_PADDING, 6],
+    [PREF_KEYS.APPEARANCE_TOKEN_LIST_ITEM_SUFFIX_PADDING, 6],
     // 外观-顶部模糊类型
     [PREF_KEYS.APPEARANCE_TOP_EFFECT_TYPE, SettingTopEffectType.IMMERSIVE_GRADIENT_BLUR],
     [PREF_KEYS.APPEARANCE_HUAWEI_CLOUD_SYNC_ENABLE, false],
@@ -527,8 +531,10 @@ export class AppPreference {
       AppPreference.getPreference(PREF_KEYS.APPEARANCE_USER_NAME_FONT_WEIGHT) as FontWeight;
     token_appearance.app_appearance_item_max_width =
       AppPreference.getPreference(PREF_KEYS.APPEARANCE_ITEM_MAX_WIDTH) as number;
-    token_appearance.app_appearance_token_list_item_horizontal_padding =
-      AppPreference.getPreference(PREF_KEYS.APPEARANCE_TOKEN_LIST_ITEM_HORIZONTAL_PADDING) as number;
+    token_appearance.app_appearance_token_list_item_prefix_padding =
+      AppPreference.getPreference(PREF_KEYS.APPEARANCE_TOKEN_LIST_ITEM_PREFIX_PADDING) as number;
+    token_appearance.app_appearance_token_list_item_suffix_padding =
+      AppPreference.getPreference(PREF_KEYS.APPEARANCE_TOKEN_LIST_ITEM_SUFFIX_PADDING) as number;
   }
 
   /**

--- a/entry/src/main/ets/utils/AppPreference.ets
+++ b/entry/src/main/ets/utils/AppPreference.ets
@@ -144,6 +144,8 @@ export enum PREF_KEYS {
   APPEARANCE_USER_NAME_FONT_WEIGHT = 'app_appearance_user_name_font_weight',
   /** Token项目最大宽度 */
   APPEARANCE_ITEM_MAX_WIDTH = 'app_appearance_item_max_width',
+  /** Token列表项目水平内边距 */
+  APPEARANCE_TOKEN_LIST_ITEM_HORIZONTAL_PADDING = 'app_appearance_token_list_item_horizontal_padding',
   /** 快速扫描URI */
   WANT_URI = 'app_want_uri',
   /** 是否启用华为云备份 */
@@ -276,6 +278,7 @@ export class TokenPreference {
   @Trace app_appearance_user_name_font_size = 10;
   @Trace app_appearance_user_name_font_weight = 400;
   @Trace app_appearance_item_max_width = 800;
+  @Trace app_appearance_token_list_item_horizontal_padding = 6;
 }
 
 /**
@@ -398,6 +401,7 @@ export class AppPreference {
     [PREF_KEYS.APPEARANCE_USER_NAME_FONT_SIZE, 10],
     [PREF_KEYS.APPEARANCE_USER_NAME_FONT_WEIGHT, 400],
     [PREF_KEYS.APPEARANCE_ITEM_MAX_WIDTH, 800],
+    [PREF_KEYS.APPEARANCE_TOKEN_LIST_ITEM_HORIZONTAL_PADDING, 6],
     // 外观-顶部模糊类型
     [PREF_KEYS.APPEARANCE_TOP_EFFECT_TYPE, SettingTopEffectType.IMMERSIVE_GRADIENT_BLUR],
     [PREF_KEYS.APPEARANCE_HUAWEI_CLOUD_SYNC_ENABLE, false],
@@ -523,6 +527,8 @@ export class AppPreference {
       AppPreference.getPreference(PREF_KEYS.APPEARANCE_USER_NAME_FONT_WEIGHT) as FontWeight;
     token_appearance.app_appearance_item_max_width =
       AppPreference.getPreference(PREF_KEYS.APPEARANCE_ITEM_MAX_WIDTH) as number;
+    token_appearance.app_appearance_token_list_item_horizontal_padding =
+      AppPreference.getPreference(PREF_KEYS.APPEARANCE_TOKEN_LIST_ITEM_HORIZONTAL_PADDING) as number;
   }
 
   /**

--- a/entry/src/main/ets/utils/CommonConstants.ets
+++ b/entry/src/main/ets/utils/CommonConstants.ets
@@ -38,6 +38,10 @@ export class CommonConstants {
   static readonly SPACE_8: number = 8;
   static readonly SPACE_12: number = 12;
   static readonly SPACE_16: number = 16;
+  // TokenItem spacing
+  static readonly TOKEN_LIST_ITEM_HORIZONTAL_PADDING: number = 10;
+  static readonly TOKEN_CARD_PREFIX_MARGIN: number = 8;
+  static readonly TOKEN_CARD_SUFFIX_MARGIN: number = 8;
   // MaxLines
   static readonly MAX_LINE_TWO: number = 2;
 

--- a/entry/src/main/ets/utils/CommonConstants.ets
+++ b/entry/src/main/ets/utils/CommonConstants.ets
@@ -40,8 +40,6 @@ export class CommonConstants {
   static readonly SPACE_16: number = 16;
   // TokenItem spacing
   static readonly TOKEN_LIST_ITEM_HORIZONTAL_PADDING: number = 10;
-  static readonly TOKEN_CARD_PREFIX_MARGIN: number = 8;
-  static readonly TOKEN_CARD_SUFFIX_MARGIN: number = 8;
   // MaxLines
   static readonly MAX_LINE_TWO: number = 2;
 

--- a/entry/src/main/ets/utils/CommonConstants.ets
+++ b/entry/src/main/ets/utils/CommonConstants.ets
@@ -39,7 +39,6 @@ export class CommonConstants {
   static readonly SPACE_12: number = 12;
   static readonly SPACE_16: number = 16;
   // TokenItem spacing
-  static readonly TOKEN_LIST_ITEM_HORIZONTAL_PADDING: number = 10;
   // MaxLines
   static readonly MAX_LINE_TWO: number = 2;
 

--- a/entry/src/main/resources/base/element/string.json
+++ b/entry/src/main/resources/base/element/string.json
@@ -673,6 +673,14 @@
       "value": "The filter can improve visibility in dark mode, but may also lose some icon details."
     },
     {
+      "name": "chain_animation",
+      "value": "Chain Animation"
+    },
+    {
+      "name": "chain_animation_des",
+      "value": "Enable staggered enter animation for list items."
+    },
+    {
       "name": "token_item_slider",
       "value": "Size & Layout"
     },

--- a/entry/src/main/resources/base/element/string.json
+++ b/entry/src/main/resources/base/element/string.json
@@ -689,8 +689,12 @@
       "value": "Space"
     },
     {
-      "name": "token_list_item_horizontal_padding",
-      "value": "Horizontal Padding"
+      "name": "token_list_item_prefix_padding",
+      "value": "Prefix Padding"
+    },
+    {
+      "name": "token_list_item_suffix_padding",
+      "value": "Suffix Padding"
     },
     {
       "name": "appearance_reset_to_default",

--- a/entry/src/main/resources/base/element/string.json
+++ b/entry/src/main/resources/base/element/string.json
@@ -689,6 +689,10 @@
       "value": "Space"
     },
     {
+      "name": "token_list_item_horizontal_padding",
+      "value": "Horizontal Padding"
+    },
+    {
       "name": "appearance_reset_to_default",
       "value": "Reset to Default"
     },

--- a/entry/src/main/resources/en_US/element/string.json
+++ b/entry/src/main/resources/en_US/element/string.json
@@ -697,8 +697,12 @@
       "value": "Space"
     },
     {
-      "name": "token_list_item_horizontal_padding",
-      "value": "Horizontal Padding"
+      "name": "token_list_item_prefix_padding",
+      "value": "Prefix Padding"
+    },
+    {
+      "name": "token_list_item_suffix_padding",
+      "value": "Suffix Padding"
     },
     {
       "name": "appearance_reset_to_default",

--- a/entry/src/main/resources/en_US/element/string.json
+++ b/entry/src/main/resources/en_US/element/string.json
@@ -697,6 +697,10 @@
       "value": "Space"
     },
     {
+      "name": "token_list_item_horizontal_padding",
+      "value": "Horizontal Padding"
+    },
+    {
       "name": "appearance_reset_to_default",
       "value": "Reset to Default"
     },

--- a/entry/src/main/resources/en_US/element/string.json
+++ b/entry/src/main/resources/en_US/element/string.json
@@ -681,6 +681,14 @@
       "value": "The filter can improve visibility in dark mode, but may also lose some icon details."
     },
     {
+      "name": "chain_animation",
+      "value": "Chain Animation"
+    },
+    {
+      "name": "chain_animation_des",
+      "value": "Enable staggered enter animation for list items."
+    },
+    {
       "name": "token_item_slider",
       "value": "Size & Layout"
     },

--- a/entry/src/main/resources/zh_CN/element/string.json
+++ b/entry/src/main/resources/zh_CN/element/string.json
@@ -681,6 +681,14 @@
       "value": "滤镜可以在深色模式时获得更好的可视度，但也有可能丢失图标细节。"
     },
     {
+      "name": "chain_animation",
+      "value": "链式联动动效"
+    },
+    {
+      "name": "chain_animation_des",
+      "value": "开启列表项的错落入场动画效果。"
+    },
+    {
       "name": "token_item_slider",
       "value": "尺寸与布局"
     },

--- a/entry/src/main/resources/zh_CN/element/string.json
+++ b/entry/src/main/resources/zh_CN/element/string.json
@@ -697,6 +697,10 @@
       "value": "间距"
     },
     {
+      "name": "token_list_item_horizontal_padding",
+      "value": "水平内边距"
+    },
+    {
       "name": "appearance_reset_to_default",
       "value": "恢复默认"
     },

--- a/entry/src/main/resources/zh_CN/element/string.json
+++ b/entry/src/main/resources/zh_CN/element/string.json
@@ -697,8 +697,12 @@
       "value": "间距"
     },
     {
-      "name": "token_list_item_horizontal_padding",
-      "value": "水平内边距"
+      "name": "token_list_item_prefix_padding",
+      "value": "左侧边距"
+    },
+    {
+      "name": "token_list_item_suffix_padding",
+      "value": "右侧边距"
     },
     {
       "name": "appearance_reset_to_default",

--- a/entry/src/main/resources/zh_TW/element/string.json
+++ b/entry/src/main/resources/zh_TW/element/string.json
@@ -677,6 +677,14 @@
       "value": "濾鏡可以在深色模式時獲得更好的可視度，但也有可能丟失圖示細節。"
     },
     {
+      "name": "chain_animation",
+      "value": "鏈式聯動動效"
+    },
+    {
+      "name": "chain_animation_des",
+      "value": "開啟列表項的錯落入場動畫效果。"
+    },
+    {
       "name": "token_item_slider",
       "value": "尺寸與佈局"
     },

--- a/entry/src/main/resources/zh_TW/element/string.json
+++ b/entry/src/main/resources/zh_TW/element/string.json
@@ -693,6 +693,10 @@
       "value": "間距"
     },
     {
+      "name": "token_list_item_horizontal_padding",
+      "value": "水平內邊距"
+    },
+    {
       "name": "appearance_reset_to_default",
       "value": "恢復預設"
     },

--- a/entry/src/main/resources/zh_TW/element/string.json
+++ b/entry/src/main/resources/zh_TW/element/string.json
@@ -693,8 +693,12 @@
       "value": "間距"
     },
     {
-      "name": "token_list_item_horizontal_padding",
-      "value": "水平內邊距"
+      "name": "token_list_item_prefix_padding",
+      "value": "左側邊距"
+    },
+    {
+      "name": "token_list_item_suffix_padding",
+      "value": "右側邊距"
     },
     {
       "name": "appearance_reset_to_default",

--- a/hvigorw
+++ b/hvigorw
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Hvigor wrapper for ohtotptoken project
+# Uses globally installed @ohos/hvigor
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export HVIGOR_HOME="$HOME/.npm-global/lib/node_modules/@ohos/hvigor"
+export NODE_OPTIONS=""
+
+# Set npm registry for HarmonyOS packages
+export npm_config_registry="https://repo.harmonyos.com/npm/"
+
+# If JDK is available, add it to PATH
+if [ -d "/usr/lib/jvm/java-17-openjdk-amd64" ]; then
+    export JAVA_HOME="/usr/lib/jvm/java-17-openjdk-amd64"
+    export PATH="$JAVA_HOME/bin:$PATH"
+fi
+
+cd "$DIR"
+exec node "$HVIGOR_HOME/bin/hvigor.js" "$@"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,194 @@
+{
+  "name": "ohtotptoken",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "@ohos/hamock": "^1.0.0",
+        "@ohos/hypium": "^1.0.27",
+        "@ohos/lottie": "^2.0.30",
+        "@ohos/protobufjs": "^3.0.1"
+      }
+    },
+    "node_modules/@ohos/hamock": {
+      "version": "1.0.0",
+      "resolved": "https://ohpm.openharmony.cn/ohpm/@ohos/hamock/-/hamock-1.0.0.har",
+      "integrity": "sha512-K6lDPYc6VkKe6ZBNQa9aoG+ZZMiwqfcR/7yAVFSUGIuOAhPvCJAo9+t1fZnpe0dBRBPxj2bxPPbKh69VuyAtDg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@ohos/hypium": {
+      "version": "1.0.27",
+      "resolved": "https://ohpm.openharmony.cn/ohpm/@ohos/hypium/-/hypium-1.0.27.har",
+      "integrity": "sha512-08ouSrneTP1K+xczK1B4hOEhsBugliwh3Q5pjBeTu3PqRMV8kUIaHHVu3wKrYE3zmjTzTXmcFQoYlLUQ7rc9lg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@ohos/lottie": {
+      "version": "2.0.30",
+      "resolved": "https://ohpm.openharmony.cn/ohpm/@ohos/lottie/-/lottie-2.0.30.har",
+      "integrity": "sha512-vbUiOY5WxWT7yEXIPFuDD75QgZFPuBKK0Zxb7rDvlcCmTFiraj73pYHHJ/Uf9XePAsoPB3wojSzdCRqH4OK5aA==",
+      "license": "MIT"
+    },
+    "node_modules/@ohos/protobufjs": {
+      "version": "3.0.1",
+      "resolved": "https://ohpm.openharmony.cn/ohpm/@ohos/protobufjs/-/protobufjs-3.0.1.har",
+      "integrity": "sha512-033wXmNedRea+hMb2z7iD+T5tq7IUDQFQFmlIcKUD2QvjZNqsYG0hj6XHP9k97wC7FslCtUksD7zIaE0oFVsKg==",
+      "license": "BSD 3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "buffer": "^6.0.3",
+        "long": "^5.2.1"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://ohpm.openharmony.cn/ohpm/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://ohpm.openharmony.cn/ohpm/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://ohpm.openharmony.cn/ohpm/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://ohpm.openharmony.cn/ohpm/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://ohpm.openharmony.cn/ohpm/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://ohpm.openharmony.cn/ohpm/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://ohpm.openharmony.cn/ohpm/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://ohpm.openharmony.cn/ohpm/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://ohpm.openharmony.cn/ohpm/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://ohpm.openharmony.cn/ohpm/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@types/node": {
+      "version": "18.15.11",
+      "resolved": "https://ohpm.openharmony.cn/ohpm/@types/node/-/node-18.15.11.tgz",
+      "integrity": "sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q==",
+      "license": "MIT"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://ohpm.openharmony.cn/ohpm/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://ohpm.openharmony.cn/ohpm/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://ohpm.openharmony.cn/ohpm/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/long": {
+      "version": "5.2.1",
+      "resolved": "https://ohpm.openharmony.cn/ohpm/long/-/long-5.2.1.tgz",
+      "integrity": "sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A==",
+      "license": "Apache-2.0"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "@ohos/hamock": "^1.0.0",
+    "@ohos/hypium": "^1.0.27",
+    "@ohos/lottie": "^2.0.30",
+    "@ohos/protobufjs": "^3.0.1"
+  }
+}


### PR DESCRIPTION
## 概述

将 TokenItem 从手写 Row 布局迁移到 HdsListItemCard 组件，并建立完整的 AppPreference 外观自定义管线。

## 主要改动

### 1. HdsListItemCard 迁移
- TokenItem 的 `build()` 由手写 `Row` → `HdsListItemCard`，使用 `PrefixCustomBuilder`/`SuffixCustomBuilder` 分别承载 TokenIcon 和 TokenCode
- 提取 `@Builder TokenIconBuilder` / `@Builder TokenCodeBuilder`
- 标题/副标题通过 `TextItemOptions` 配置，字体由 `AppPreference` 驱动

### 2. QR Code 右滑合并
- 原左滑 QR Code 合并到右滑菜单（QR + 编辑 + 删除），减少滑动冲突

### 3. 左右独立边距
- `cardPrefixMargin` / `cardSuffixMargin` 走 `AppPreference` 管线，默认 10px
- 用户在「自定义外观 → 自定义布局」中可分别调整左右边距（0~30，步长 1）
- 预览区 TokenItem 同步响应

### 4. 字体样式实时响应
- `primaryText` / `secondaryText` 使用 `customBuilder` + `@Builder TextContentBuilder`，绕过 `TextModifier` 在 `HdsListItemCard` 中动态更新失效的问题
- 发行者/用户名 字体大小、字重调整后，预览区和列表页均实时生效
- 补充 `textOverflow(MARQUEE) + maxLines(1)`，恢复溢出跑马灯效果

### 5. 链式联动动效全局开关
- 新增「链式联动动效」开关（默认开启），统一控制 7 个页面/对话框的 `chainAnimation`
- 关闭后列表项错落入场动画消失

### 6. 其他
- 强制单列 lanes 确保链式动效正常工作
- TokenIcon / TokenCode 添加系统标准 padding
- 外观预览区移除硬编码 padding，消除双重叠加