### PR TITLE
feat(ci): 扩展CI/CD管线——合入main自动构建与发布Release

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,7 +1,8 @@
 name: build
 
 on:
-  push:
+  pull_request:
+    types: [closed]
     branches:
       - main
     paths-ignore:
@@ -24,6 +25,7 @@ on:
 jobs:
   build_ohos:
     name: Build for ohos
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     permissions: write-all
     steps:
@@ -38,12 +40,15 @@ jobs:
         with:
           version: latest
           cache: true
-      - name: Install dependencies
+
+      - name: Install system dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y curl libgl1-mesa-dev
         shell: bash
-      - run: hvigorw -v
+
+      - name: Verify hvigorw
+        run: hvigorw -v
 
       - name: Install project dependencies
         run: |
@@ -53,6 +58,13 @@ jobs:
         run: hvigorw clean assembleHap -p buildMode=release --config properties.ignoreSignHap=true
         shell: bash
 
+      - name: Extract version
+        id: version
+        run: |
+          VERSION=$(grep '"versionName"' AppScope/app.json5 | sed 's/.*"versionName"[^"]*"\([^"]*\)".*/\1/')
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "Extracted version: ${VERSION}"
+
       - name: Rename hap
         run: |
           HAP_FILE=$(find "${{ github.workspace }}/entry/build" -name "*.hap" -type f | head -n 1)
@@ -61,12 +73,21 @@ jobs:
             exit 1
           fi
           echo "Found hap: $HAP_FILE"
-          cp "$HAP_FILE" "${{ github.workspace }}/ohtotptoken_ohos_canary.hap"
+          cp "$HAP_FILE" "${{ github.workspace }}/ohtotptoken_${{ steps.version.outputs.version }}_unsigned.hap"
 
-      - name: Upload hap
+      - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: ohos_outputs
-          path: ${{ github.workspace }}/ohtotptoken_ohos_canary.hap
+          path: ${{ github.workspace }}/ohtotptoken_${{ steps.version.outputs.version }}_unsigned.hap
           if-no-files-found: error
           retention-days: 30
+
+      - name: Create Release
+        if: github.event_name != 'workflow_dispatch'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ steps.version.outputs.version }}
+          name: v${{ steps.version.outputs.version }}
+          files: ohtotptoken_${{ steps.version.outputs.version }}_unsigned.hap
+          generate_release_notes: true

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -87,7 +87,7 @@ jobs:
         if: github.event_name != 'workflow_dispatch'
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: v${{ steps.version.outputs.version }}
-          name: v${{ steps.version.outputs.version }}
+          tag_name: ${{ steps.version.outputs.version }}
+          name: ${{ steps.version.outputs.version }}
           files: ohtotptoken_${{ steps.version.outputs.version }}_unsigned.hap
           generate_release_notes: true


### PR DESCRIPTION
## 概述

扩展原有 CI/CD 管线，使 PR 合入 `main` 后自动构建 HAP 并发布 GitHub Release。

## 变更

**触发方式**

- 从 `push: main` 改为 `pull_request: closed → main`
- 新增 `if: merged == true` 条件，仅在 PR 实际合入后触发
- `workflow_dispatch` 手动触发保留

**版本提取**

- 新增步骤从 `AppScope/app.json5` 读取 `versionName`
- 版本号用于 hap 命名和 Release tag

**hap 命名**

- 从 `ohtotptoken_ohos_canary.hap` 改为 `ohtotptoken_{version}_unsigned.hap`

**自动发布 Release**

- 新增 `softprops/action-gh-release@v2` 步骤
- 正式 Release（非 prerelease），hap 直出（非 zip）
- Release tag 直接使用版本号（如 `1.2.3`），不加 `v` 前缀
- 仅在 PR merge 时执行，手动 dispatch 跳过

**paths-ignore**

- 保留原有规则：`docs/**`、`.gitignore`、`**.md`