### PR TITLE
refactor: 搜索功能改为独立页面与标题栏使能安全区避让模糊

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "typescript.validate.enable": false,
+    "typescript.suggest.enabled": false
+}

--- a/AppScope/app.json5
+++ b/AppScope/app.json5
@@ -2,7 +2,7 @@
   "app": {
     "bundleName": "smartcityshenzhen.yylx.totptoken",
     "vendor": "opensource",
-    "versionCode": 1002050,
+    "versionCode": 1002051,
     "versionName": "1.2.5",
     "icon": "$media:app_icon",
     "label": "$string:app_name",

--- a/build-profile.json5
+++ b/build-profile.json5
@@ -5,13 +5,13 @@
         "name": "default",
         "type": "HarmonyOS",
         "material": {
-          "certpath": "C:\\Users\\evelo\\.ohos\\config\\default_ohtotptoken_V9sJGc5Sthk3VHwBTW8ioyLx7Yr9aJmD60s1yuv5aGw=.cer",
+          "certpath": "C:\\Users\\PC\\.ohos\\config\\default_ohtotptoken_EoFbYjQ21YyI6klIPwGuRezi5pWw2uTKD2aaUhgpuik=.cer",
           "keyAlias": "debugKey",
-          "keyPassword": "0000001A28FE9E6CC7CC19376378073E66A0AD826FF8C95C33EB7F83E2CEF318CC962B1C8D7C0C718403",
-          "profile": "C:\\Users\\evelo\\.ohos\\config\\default_ohtotptoken_V9sJGc5Sthk3VHwBTW8ioyLx7Yr9aJmD60s1yuv5aGw=.p7b",
+          "keyPassword": "0000001B1F03EA84434365246E9FEEA6974DFA628BAFA708AFF70E66EEAE3E13EB78EBC9A8C267791217F2",
+          "profile": "C:\\Users\\PC\\.ohos\\config\\default_ohtotptoken_EoFbYjQ21YyI6klIPwGuRezi5pWw2uTKD2aaUhgpuik=.p7b",
           "signAlg": "SHA256withECDSA",
-          "storeFile": "C:\\Users\\evelo\\.ohos\\config\\default_ohtotptoken_V9sJGc5Sthk3VHwBTW8ioyLx7Yr9aJmD60s1yuv5aGw=.p12",
-          "storePassword": "0000001A64DC643C992B600B44339E258E01C77B28C8A9170639EFD34F3FF030173AD8B2D645345E4173"
+          "storeFile": "C:\\Users\\PC\\.ohos\\config\\default_ohtotptoken_EoFbYjQ21YyI6klIPwGuRezi5pWw2uTKD2aaUhgpuik=.p12",
+          "storePassword": "0000001BC2A291F4623805FFDDF6678900E4AAABC899D6A5395B8DCCA164943C1801CF927CFD60B02A3696"
         }
       }
     ],

--- a/entry/src/main/ets/components/ArcTokenItem.ets
+++ b/entry/src/main/ets/components/ArcTokenItem.ets
@@ -11,6 +11,7 @@ import { QRCodeDialog } from '../dialogs/QRCodeDialog';
 import { AppWindowInfo } from '../entryability/EntryAbility';
 import { TokenStore } from '../utils/TokenStore';
 import { ConfigurationConstant, common } from '@kit.AbilityKit';
+import { AppFonts } from '../utils/AppFonts';
 import { ArcTokenIcon } from './ArcTokenIcon';
 
 let current_token_hide_map: Map<string, boolean> = new Map();
@@ -217,6 +218,7 @@ export struct ArcTokenItem {
             .fontColor('#ffe0e0e0')
             .fontSize(this.token_preference.app_appearance_token_font_size)
             .fontWeight(this.token_preference.app_appearance_token_font_weight)
+            .fontFamily(AppFonts.CODE_FONT)
             .gesture(
               LongPressGesture()
                 .onAction(() => {
@@ -237,6 +239,7 @@ export struct ArcTokenItem {
               .maxLines(1)
               .fontColor($r('app.color.str_gray'))
               .fontSize(10)
+              .fontFamily(AppFonts.CODE_FONT)
           }
         }
         .onClick(() => {

--- a/entry/src/main/ets/components/SubItemIconManager.ets
+++ b/entry/src/main/ets/components/SubItemIconManager.ets
@@ -5,7 +5,7 @@ import { AegisIconPack, TokenIconPacks } from '../utils/TokenUtils';
 import { BusinessError, zlib } from '@kit.BasicServicesKit';
 import { AppStorageV2 } from '@kit.ArkUI';
 import { SubItemDivider } from './SubItemDivider';
-import { AppPreference, BUILTIN_DEFAULT_PACK_ID } from '../utils/AppPreference';
+import { AppPreference, BUILTIN_DEFAULT_PACK_ID, PREF_KEYS } from '../utils/AppPreference';
 import { AppWindowInfo } from '../entryability/EntryAbility';
 import { throttle, startBrowsableAbility } from '../utils/UiUtils';
 import { showSnackBar, SnackBarNotifyType } from '../utils/HdsSnackBarUtils';
@@ -451,6 +451,23 @@ export struct SubItemIconManager {
           }
           .width('100%')
           .margin({ top: 10 })
+
+          if (AppPreference.getPreference(PREF_KEYS.APPEARANCE_HUAWEI_CLOUD_SYNC_ENABLE) as boolean) {
+            Row() {
+              SymbolGlyph($r('sys.symbol.info_circle'))
+                .fontSize(16)
+                .fontColor([$r('sys.color.ohos_id_color_text_secondary')])
+                .margin({ right: 6 })
+              Text($r('app.string.icon_pack_cloud_backup_hint'))
+                .fontSize($r('sys.float.ohos_id_text_size_caption'))
+                .fontColor($r('sys.color.ohos_id_color_text_secondary'))
+                .fontWeight(FontWeight.Regular)
+                .layoutWeight(1)
+            }
+            .width('100%')
+            .margin({ top: 8 })
+            .padding({ left: 4, right: 4 })
+          }
         }
         .width('100%')
       }

--- a/entry/src/main/ets/components/TokenItem.ets
+++ b/entry/src/main/ets/components/TokenItem.ets
@@ -18,6 +18,7 @@ import {
   SuffixCustomBuilder
 } from '@kit.UIDesignKit';
 import { CommonConstants } from '../utils/CommonConstants';
+import { AppFonts } from '../utils/AppFonts';
 
 let current_token_hide_map: Map<string, boolean> = new Map();
 let tkStore = TokenStore.getInstance();
@@ -227,6 +228,7 @@ export struct TokenItem {
                 this.token_color_expiring : this.token_color_normal)
               .fontSize(this.token_preference.app_appearance_token_font_size)
               .fontWeight(this.token_preference.app_appearance_token_font_weight)
+              .fontFamily(AppFonts.CODE_FONT)
               .gesture(
                 LongPressGesture()
                   .onAction(() => {
@@ -247,6 +249,7 @@ export struct TokenItem {
                 .maxLines(1)
                 .fontColor($r('app.color.str_gray'))
                 .fontSize(10)
+                .fontFamily(AppFonts.CODE_FONT)
             }
           }
 

--- a/entry/src/main/ets/pages/AppearancePage.ets
+++ b/entry/src/main/ets/pages/AppearancePage.ets
@@ -40,23 +40,33 @@ export struct AppearancePage {
   // 健康路径下兜底计时器虽每秒触发一次，但不产生 emit（不触发 TokenItem 重复计算 HMAC），开销可忽略。
   private timestampIntervalId: number = -1;
   private lastTimestampTick: number = 0;
+  // 标记“正在由本页兜底广播”，避免自身 emit 同步回调时误刷新心跳。
+  private selfEmitting: boolean = false;
   private onTimestampHandler: () => void = () => {};
   // 判定全局心跳缺失的阈值（毫秒）。全局计时器为 1s 一次，取 1.5s 留出抖动余量。
   private static readonly HEARTBEAT_TIMEOUT_MS: number = 1500;
 
   aboutToAppear(): void {
     this.lastTimestampTick = systemDateTime.getTime();
-    // 仅用于探测全局心跳：收到事件即刷新最近心跳时间，参数本身不使用。
+    // 仅用于探测全局心跳：仅当事件来源为“全局 Index”（非本页兜底）时才刷新心跳时间。
+    // 若不区分来源，本页兜底广播会经 eventHub 同步回调自身，把心跳刷新为当前时间，
+    // 导致兜底计时器每 2s 才触发一次（出现卡顿）。
     this.onTimestampHandler = (): void => {
-      this.lastTimestampTick = systemDateTime.getTime();
+      if (!this.selfEmitting) {
+        this.lastTimestampTick = systemDateTime.getTime();
+      }
     };
     this.context.eventHub?.on(EVENT_NAMES.TIMESTAMP_CHANGED, this.onTimestampHandler);
 
-    // 兜底计时器：仅在全局心跳超时时才广播，避免与 Index 重复推送
+    // 兜底计时器：仅在全局心跳超时时才广播，避免与 Index 重复推送。
+    // eventHub.emit 为同步调用，故用 selfEmitting 标志包裹以阻止自身回调污染心跳，
+    // 保证全局心跳缺失时兜底能稳定每 1s 广播一次。
     this.timestampIntervalId = setInterval(() => {
       if (systemDateTime.getTime() - this.lastTimestampTick > AppearancePage.HEARTBEAT_TIMEOUT_MS) {
         const timestamp = Math.floor(systemDateTime.getTime() / 1000);
+        this.selfEmitting = true;
         this.context.eventHub?.emit(EVENT_NAMES.TIMESTAMP_CHANGED, timestamp, false);
+        this.selfEmitting = false;
       }
     }, 1000);
   }

--- a/entry/src/main/ets/pages/AppearancePage.ets
+++ b/entry/src/main/ets/pages/AppearancePage.ets
@@ -593,14 +593,6 @@ export struct AppearancePage {
               iconColor: $r('sys.color.icon_primary')
             }
           },
-          backgroundStyle: {
-            maskExtraHeight: 0
-          }
-        },
-        scrollEffectStyle: {
-          backgroundStyle: {
-            maskExtraHeight: 0
-          }
         },
         scrollEffectOpts: {
           enableScrollEffect: true,

--- a/entry/src/main/ets/pages/AppearancePage.ets
+++ b/entry/src/main/ets/pages/AppearancePage.ets
@@ -28,21 +28,44 @@ export struct AppearancePage {
   // 使用 AppStorage 获取 context，避免在字段初始化阶段调用 getUIContext()（此时 build() 尚未执行）
   private context: common.UIAbilityContext = AppStorage.get('appContext') as common.UIAbilityContext;
   private scroller: Scroller = new Scroller();
+
+  // [性能优化] 本页不再无条件自建 1s 计时器。
+  // 首页 Index 持有全局唯一时间计时器，每秒经 eventHub 广播 TIMESTAMP_CHANGED，
+  // 预览区内的 TokenItem 自身已订阅该事件，正常情况下可直接复用、无需重复推送。
+  //
+  // [防御性兜底] 为避免对“Index 必然挂载且其计时器必然在跑”这一隐式假设产生硬依赖
+  // （例如未来路由调整使本页在 Index 之外打开），这里订阅 TIMESTAMP_CHANGED 来探测全局心跳：
+  //   - 收到事件 → 记录最近心跳时间，说明全局源健康，本页不做任何额外推送；
+  //   - 超过阈值仍无心跳 → 全局源疑似缺失，本页启动兜底计时器自行广播，保证预览倒计时持续刷新。
+  // 健康路径下兜底计时器虽每秒触发一次，但不产生 emit（不触发 TokenItem 重复计算 HMAC），开销可忽略。
   private timestampIntervalId: number = -1;
+  private lastTimestampTick: number = 0;
+  private onTimestampHandler: () => void = () => {};
+  // 判定全局心跳缺失的阈值（毫秒）。全局计时器为 1s 一次，取 1.5s 留出抖动余量。
+  private static readonly HEARTBEAT_TIMEOUT_MS: number = 1500;
 
   aboutToAppear(): void {
+    this.lastTimestampTick = systemDateTime.getTime();
+    // 仅用于探测全局心跳：收到事件即刷新最近心跳时间，参数本身不使用。
+    this.onTimestampHandler = (): void => {
+      this.lastTimestampTick = systemDateTime.getTime();
+    };
+    this.context.eventHub?.on(EVENT_NAMES.TIMESTAMP_CHANGED, this.onTimestampHandler);
+
+    // 兜底计时器：仅在全局心跳超时时才广播，避免与 Index 重复推送
     this.timestampIntervalId = setInterval(() => {
-      const timestamp = Math.floor(systemDateTime.getTime() / 1000);
-      if (this.context.eventHub != undefined) {
-        this.context.eventHub.emit(EVENT_NAMES.TIMESTAMP_CHANGED, timestamp, false);
+      if (systemDateTime.getTime() - this.lastTimestampTick > AppearancePage.HEARTBEAT_TIMEOUT_MS) {
+        const timestamp = Math.floor(systemDateTime.getTime() / 1000);
+        this.context.eventHub?.emit(EVENT_NAMES.TIMESTAMP_CHANGED, timestamp, false);
       }
     }, 1000);
   }
 
-  // 清理 setInterval，防止页面弹出后计时器持续泄漏
   aboutToDisappear(): void {
+    this.context.eventHub?.off(EVENT_NAMES.TIMESTAMP_CHANGED, this.onTimestampHandler);
     if (this.timestampIntervalId !== -1) {
       clearInterval(this.timestampIntervalId);
+      this.timestampIntervalId = -1;
     }
   }
 

--- a/entry/src/main/ets/pages/Index.ets
+++ b/entry/src/main/ets/pages/Index.ets
@@ -962,13 +962,6 @@ struct Index {
   @Builder
   SettingEntryCardBuilder() {
     List({ space: 10, scroller: this.settingEntryScroller }) {
-      // 顶部占位空间，用于触发渐变模糊效果
-      ListItem() {
-        Column()
-          .width('100%')
-          .height(CommonConstants.AVOID_TOP_BASE_HEIGHT + this.window.AvoidTopHeight)
-      }
-
       // 华为账号登录卡片
       ListItem() {
         Row({ space: 16 }) {
@@ -1337,6 +1330,7 @@ struct Index {
         right: $r('sys.float.padding_level8'),
       })
     }
+    .clip(false)
     .chainAnimation(this.token_preference.app_appearance_chain_animation_enable)
     .width('100%')
     .height('100%')
@@ -1367,250 +1361,244 @@ struct Index {
   }
 
   build() {
-    Navigation(this.pageInfos) {
-    Stack() {
-      if (this.token_loading) {
-        Column() {
-          LoadingProgress()
-            .color(Color.White)
-          .width(80).height(80)
-        Text('Loading..')
-          .fontSize(16)
-          .fontColor(Color.White)
+    HdsNavigation(this.pageInfos) {
+      Stack() {
+        if (this.token_loading) {
+          Column() {
+            LoadingProgress()
+              .color(Color.White)
+              .width(80).height(80)
+            Text('Loading..')
+              .fontSize(16)
+              .fontColor(Color.White)
+          }
+          .width('100%')
+          .height('100%')
+          .backgroundColor('#40000000')
+          .justifyContent(FlexAlign.Center)
+        } else if (
+          (this.window.HeightBreakpoint === HeightBreakpoint.HEIGHT_MD) &&
+            this.window.WidthBreakpoint === WidthBreakpoint.WIDTH_XS
+        ) {
+          ArcTokenListPage({
+            Tokens: this.CurrentTokens,
+            TabBarVisible: false,
+            appBottomAvoidHeight: this.window.AvoidBottomHeight,
+            appTopAvoidHeight: this.window.AvoidTopHeight,
+            appWindowSize: this.window.Size,
+            updateTokenConfig: this.updateTokenConfig,
+            updateTokenConfigs: this.updateTokenConfigs,
+            listScroller: this.arcTokenListScroller,
+          })
+        } else if (
+          (this.window.HeightBreakpoint === HeightBreakpoint.HEIGHT_MD ||
+            this.window.HeightBreakpoint === HeightBreakpoint.HEIGHT_SM) &&
+            this.window.WidthBreakpoint === WidthBreakpoint.WIDTH_SM
+        ) {
+          Column() {
+            TokenListPage({
+              Tokens: this.CurrentTokens,
+              TabBarVisible: false,
+              appBottomAvoidHeight: this.window.AvoidBottomHeight,
+              appTopAvoidHeight: this.window.AvoidTopHeight,
+              appWindowSize: this.window.Size,
+              updateTokenConfig: this.updateTokenConfig,
+              updateTokenConfigs: this.updateTokenConfigs,
+              listScroller: this.tokenListScroller,
+            })
+          }
+          .backgroundColor($r('app.color.window_background'))
+        } else {
+
+          Column() {
+            HdsTabs({ index: this.tab_bar_index }) {
+              TabContent() {
+                HdsNavigation() {
+                  TokenListPage({
+                    Tokens: this.CurrentTokens,
+                    TabBarVisible: true,
+                    appBottomAvoidHeight: this.window.AvoidBottomHeight,
+                    appTopAvoidHeight: this.window.AvoidTopHeight,
+                    appWindowSize: this.window.Size,
+                    updateTokenConfig: this.updateTokenConfig,
+                    updateTokenConfigs: this.updateTokenConfigs,
+                    listScroller: this.tokenListScroller,
+                  })
+                }
+                .mode(NavigationMode.Stack)
+                .bindToScrollable([this.tokenListScroller])
+                .titleMode(HdsNavigationTitleMode.MINI)
+                .hideBackButton(true) // 设置mini类型隐藏后退按钮
+                .titleBar({
+                  avoidLayoutSafeArea: true, // 状态栏安全区沉浸
+                  enableComponentSafeArea: true,
+                  style: {
+                    originalStyle: {
+                      contentStyle: {
+                        titleStyle: {
+                          mainTitleColor: $r('sys.color.font_primary'),
+                        },
+                        menuStyle: {
+                          iconColor: $r('sys.color.icon_primary')
+                        },
+                      }
+                    },
+                    scrollEffectOpts: {
+                      enableScrollEffect: true,
+                      scrollEffectType: this.currentScrollEffectType // 渐变模糊
+                    },
+                    systemMaterialEffect: {
+                      materialType: hdsMaterial.MaterialType.ADAPTIVE,
+                      materialLevel: hdsMaterial.MaterialLevel.ADAPTIVE
+                    }
+                  },
+                  content: {
+                    title: {
+                      mainTitle: $r('app.string.EntryAbility_label'),
+                    },
+                    menu: {
+                      value: [
+                        {
+                          content: {
+                            label: $r('app.string.app_ua_search_token'),
+                            icon: $r('sys.symbol.magnifyingglass'),
+                            isEnabled: true,
+                            action: () => {
+                              if (this.appCtx.eventHub != undefined) this.appCtx.eventHub.emit(EVENT_NAMES.TOGGLE_TOKEN_SEARCH);
+                            }
+                          }
+                        },
+                        {
+                          content: {
+                            label: $r('app.string.app_ua_add_token'),
+                            icon: $r('sys.symbol.plus'),
+                            isEnabled: true,
+                            componentId: this.addTokenMenuTargetId,
+                            action: () => {
+                              this.openAddTokenMenu();
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                })
+              }
+              .backgroundColor($r('app.color.window_background'))
+              .tabBar(BottomTabBarStyle.of(
+                {
+                  normal: new SymbolGlyphModifier($r('sys.symbol.key_fill')),
+                  selected: new SymbolGlyphModifier($r('sys.symbol.key_fill'))
+                },
+                $r('app.string.tab_token'))
+                .verticalAlign(VerticalAlign.Center)
+              )
+              .tabIndex(0)
+
+              TabContent() {
+                // [冷启动优化] Setting Tab 懒加载：仅在用户首次切换到"我的"Tab 时构建组件树，
+                // 避免冷启动时一次性构建两个 TabContent 导致首帧 build 耗时增加
+                if (this.settingTabInitialized) {
+                  HdsNavigation() {
+                    this.SettingEntryCardBuilder()
+                  }
+                  .mode(NavigationMode.Stack)
+                  .bindToScrollable([this.settingEntryScroller])
+                  .titleMode(HdsNavigationTitleMode.MINI)
+                  .hideBackButton(true)
+                  .titleBar({
+                    avoidLayoutSafeArea: true,
+                    enableComponentSafeArea: true,
+                    style: {
+                      originalStyle: {
+                        contentStyle: {
+                          titleStyle: {
+                            mainTitleColor: $r('sys.color.font_primary'),
+                          },
+                          menuStyle: {
+                            iconColor: $r('sys.color.icon_primary')
+                          },
+                        },
+                      },
+                      scrollEffectOpts: {
+                        enableScrollEffect: true,
+                        scrollEffectType: this.currentScrollEffectType,
+                      },
+                      systemMaterialEffect: {
+                        materialType: hdsMaterial.MaterialType.ADAPTIVE,
+                        materialLevel: hdsMaterial.MaterialLevel.ADAPTIVE
+                      }
+                    },
+                    content: {
+                      title: {
+                        mainTitle: $r('app.string.tab_me')
+                      },
+                      menu: {
+                        value: []
+                      }
+                    }
+                  })
+                }
+              }
+              .backgroundColor($r('app.color.window_background'))
+              .tabBar(BottomTabBarStyle.of(
+                {
+                  normal: new SymbolGlyphModifier($r('sys.symbol.person_crop_circle_fill_1')),
+                  selected: new SymbolGlyphModifier($r('sys.symbol.person_crop_circle_fill_1')),
+                },
+                $r('app.string.tab_me'))
+                .verticalAlign(VerticalAlign.Center)
+              )
+              .tabIndex(1)
+            }
+            .barBackgroundColor($r('app.color.tab_bar_bg'))
+            .backgroundColor($r('app.color.window_background'))
+            .layoutWeight(1)
+            .barOverlap(true)
+            .barBackgroundColor(Color.Transparent)
+            .barBackgroundBlurStyle(BlurStyle.Regular)
+            .barPosition(BarPosition.End)
+            .barFloatingStyle({
+              barBottomMargin: 28,
+              systemMaterialEffect: {
+                materialType: hdsMaterial.MaterialType.ADAPTIVE,
+                materialLevel: hdsMaterial.MaterialLevel.ADAPTIVE
+              }
+            })
+            .vertical(false)
+            .barMode(BarMode.Fixed)
+            .animationDuration(300)
+            .onChange((index) => {
+              this.tab_bar_index = index;
+              // [冷启动优化] 用户首次切换到 Setting Tab 时触发懒加载构建
+              if (index === 1 && !this.settingTabInitialized) {
+                this.settingTabInitialized = true;
+              }
+            })
+          }
+        }
       }
       .width('100%')
       .height('100%')
-      .backgroundColor('#40000000')
-      .justifyContent(FlexAlign.Center)
-    } else if (
-      (this.window.HeightBreakpoint === HeightBreakpoint.HEIGHT_MD) &&
-        this.window.WidthBreakpoint === WidthBreakpoint.WIDTH_XS
-    ) {
-      ArcTokenListPage({
-        Tokens: this.CurrentTokens,
-        TabBarVisible: false,
-        appBottomAvoidHeight: this.window.AvoidBottomHeight,
-        appTopAvoidHeight: this.window.AvoidTopHeight,
-        appWindowSize: this.window.Size,
-        updateTokenConfig: this.updateTokenConfig,
-        updateTokenConfigs: this.updateTokenConfigs,
-        listScroller: this.arcTokenListScroller,
+      .allowDrop([uniformTypeDescriptor.UniformDataType.FILE])
+      .onDrop(() => {
+        this.DropFilesDialogIsOpen = false;
+        this.DropFilesDialogController?.close();
       })
-    } else if (
-      (this.window.HeightBreakpoint === HeightBreakpoint.HEIGHT_MD ||
-        this.window.HeightBreakpoint === HeightBreakpoint.HEIGHT_SM) &&
-        this.window.WidthBreakpoint === WidthBreakpoint.WIDTH_SM
-    ) {
-      Column() {
-        TokenListPage({
-          Tokens: this.CurrentTokens,
-          TabBarVisible: false,
-          appBottomAvoidHeight: this.window.AvoidBottomHeight,
-          appTopAvoidHeight: this.window.AvoidTopHeight,
-          appWindowSize: this.window.Size,
-          updateTokenConfig: this.updateTokenConfig,
-          updateTokenConfigs: this.updateTokenConfigs,
-          listScroller: this.tokenListScroller,
-        })
-      }
-      .backgroundColor($r('app.color.window_background'))
-    } else {
-
-      Column() {
-        HdsTabs({ index: this.tab_bar_index }) {
-          TabContent() {
-            HdsNavigation() {
-              TokenListPage({
-                Tokens: this.CurrentTokens,
-                TabBarVisible: true,
-                appBottomAvoidHeight: this.window.AvoidBottomHeight,
-                appTopAvoidHeight: this.window.AvoidTopHeight,
-                appWindowSize: this.window.Size,
-                updateTokenConfig: this.updateTokenConfig,
-                updateTokenConfigs: this.updateTokenConfigs,
-                listScroller: this.tokenListScroller,
-              })
-            }
-            .mode(NavigationMode.Stack)
-            .bindToScrollable([this.tokenListScroller])
-            .titleMode(HdsNavigationTitleMode.MINI)
-            .hideBackButton(true) // 设置mini类型隐藏后退按钮
-            .titleBar({
-              avoidLayoutSafeArea: true, // 状态栏安全区沉浸
-              style: {
-                originalStyle: {
-                  contentStyle: {
-                    titleStyle: {
-                      mainTitleColor: $r('sys.color.font_primary'),
-                    },
-                    menuStyle: {
-                      iconColor: $r('sys.color.icon_primary')
-                    },
-                  }
-                },
-                scrollEffectOpts: {
-                  enableScrollEffect: true,
-                  scrollEffectType: this.currentScrollEffectType // 渐变模糊
-                },
-                systemMaterialEffect: {
-                  materialType: hdsMaterial.MaterialType.ADAPTIVE,
-                  materialLevel: hdsMaterial.MaterialLevel.ADAPTIVE
-                }
-              },
-              content: {
-                title: {
-                  mainTitle: $r('app.string.EntryAbility_label'),
-                },
-                menu: {
-                  value: [
-                    {
-                      content: {
-                        label: $r('app.string.app_ua_search_token'),
-                        icon: $r('sys.symbol.magnifyingglass'),
-                        isEnabled: true,
-                        action: () => {
-                          if (this.appCtx.eventHub != undefined) this.appCtx.eventHub.emit(EVENT_NAMES.TOGGLE_TOKEN_SEARCH);
-                        }
-                      }
-                    },
-                    {
-                      content: {
-                        label: $r('app.string.app_ua_add_token'),
-                        icon: $r('sys.symbol.plus'),
-                        isEnabled: true,
-                        componentId: this.addTokenMenuTargetId,
-                        action: () => {
-                          this.openAddTokenMenu();
-                        }
-                      }
-                    }
-                  ]
-                }
-              }
-            })
-          }
-          .backgroundColor($r('app.color.window_background'))
-          .tabBar(BottomTabBarStyle.of(
-            {
-              normal: new SymbolGlyphModifier($r('sys.symbol.key_fill')),
-              selected: new SymbolGlyphModifier($r('sys.symbol.key_fill'))
-            },
-            $r('app.string.tab_token'))
-            .verticalAlign(VerticalAlign.Center)
-          )
-          .tabIndex(0)
-
-          TabContent() {
-            // [冷启动优化] Setting Tab 懒加载：仅在用户首次切换到"我的"Tab 时构建组件树，
-            // 避免冷启动时一次性构建两个 TabContent 导致首帧 build 耗时增加
-            if (this.settingTabInitialized) {
-              HdsNavigation() {
-                this.SettingEntryCardBuilder()
-              }
-              .mode(NavigationMode.Stack)
-              .bindToScrollable([this.settingEntryScroller])
-              .titleMode(HdsNavigationTitleMode.MINI)
-              .hideBackButton(true)
-              .titleBar({
-                avoidLayoutSafeArea: true,
-                style: {
-                  originalStyle: {
-                    contentStyle: {
-                      titleStyle: {
-                        mainTitleColor: $r('sys.color.font_primary'),
-                      },
-                      menuStyle: {
-                        iconColor: $r('sys.color.icon_primary')
-                      },
-                    },
-                  backgroundStyle: {
-                    maskExtraHeight: 0
-                  }
-                },
-                scrollEffectStyle: {
-                  backgroundStyle: {
-                    maskExtraHeight: 0
-                  }
-                },
-                scrollEffectOpts: {
-                  enableScrollEffect: true,
-                  scrollEffectType: this.currentScrollEffectType
-                },
-                systemMaterialEffect: {
-                  materialType: hdsMaterial.MaterialType.ADAPTIVE,
-                  materialLevel: hdsMaterial.MaterialLevel.ADAPTIVE
-                }
-              },
-              content: {
-                title: {
-                  mainTitle: $r('app.string.tab_me')
-                },
-                menu: {
-                  value: []
-                }
-              }
-            })
-            }
-          }
-          .backgroundColor($r('app.color.window_background'))
-          .tabBar(BottomTabBarStyle.of(
-            {
-              normal: new SymbolGlyphModifier($r('sys.symbol.person_crop_circle_fill_1')),
-              selected: new SymbolGlyphModifier($r('sys.symbol.person_crop_circle_fill_1')),
-            },
-            $r('app.string.tab_me'))
-            .verticalAlign(VerticalAlign.Center)
-          )
-          .tabIndex(1)
+      .onDragEnter(() => {
+        if (!this.DropFilesDialogIsOpen) {
+          this.DropFilesDialogIsOpen = true;
+          this.DropFilesDialogController?.open();
         }
-        .barBackgroundColor($r('app.color.tab_bar_bg'))
-        .backgroundColor($r('app.color.window_background'))
-        .layoutWeight(1)
-        .barOverlap(true)
-        .barBackgroundColor(Color.Transparent)
-        .barBackgroundBlurStyle(BlurStyle.Regular)
-        .barPosition(BarPosition.End)
-        .barFloatingStyle({
-          barBottomMargin: 28,
-          systemMaterialEffect: {
-            materialType: hdsMaterial.MaterialType.ADAPTIVE,
-            materialLevel: hdsMaterial.MaterialLevel.ADAPTIVE
-          }
-        })
-        .vertical(false)
-        .barMode(BarMode.Fixed)
-        .animationDuration(300)
-        .onChange((index) => {
-          this.tab_bar_index = index;
-          // [冷启动优化] 用户首次切换到 Setting Tab 时触发懒加载构建
-          if (index === 1 && !this.settingTabInitialized) {
-            this.settingTabInitialized = true;
-          }
-        })
-      }
-      }
-    }
-    .width('100%')
-    .height('100%')
-    .allowDrop([uniformTypeDescriptor.UniformDataType.FILE])
-    .onDrop(() => {
-      this.DropFilesDialogIsOpen = false;
-      this.DropFilesDialogController?.close();
-    })
-    .onDragEnter(() => {
-      if (!this.DropFilesDialogIsOpen) {
-        this.DropFilesDialogIsOpen = true;
-        this.DropFilesDialogController?.open();
-      }
-    })
-    .onDragLeave(() => {
-      this.DropFilesDialogIsOpen = false;
-      this.DropFilesDialogController?.close();
-    })
-    .foregroundBlurStyle((this.background_blur_flag || this.isAppLockOverlayVisible) ? BlurStyle.Thin : BlurStyle.NONE, {
-      colorMode: ThemeColorMode.SYSTEM,
-      adaptiveColor: AdaptiveColor.DEFAULT
-    })
+      })
+      .onDragLeave(() => {
+        this.DropFilesDialogIsOpen = false;
+        this.DropFilesDialogController?.close();
+      })
+      .foregroundBlurStyle((this.background_blur_flag || this.isAppLockOverlayVisible) ? BlurStyle.Thin : BlurStyle.NONE, {
+        colorMode: ThemeColorMode.SYSTEM,
+        adaptiveColor: AdaptiveColor.DEFAULT
+      })
     }
     .hideTitleBar(true)
     .mode(NavigationMode.Stack)

--- a/entry/src/main/ets/pages/Index.ets
+++ b/entry/src/main/ets/pages/Index.ets
@@ -69,6 +69,7 @@ import lazy { SteamConfigDialog } from '../dialogs/SteamConfigDialog';
 import { CommonConstants } from '../utils/CommonConstants';
 // [冷启动优化] 华为账号管理器仅在 deferredInit 中初始化
 import lazy { HuaweiAccountManager, HuaweiUserInfo, HuaweiAccountLoginError } from '../utils/HuaweiAccountManager';
+import lazy { IconPackCloudBackup } from '../utils/IconPackCloudBackup';
 import { DlpAntiPeepManager } from '../utils/DlpAntiPeepManager';
 
 const TAG = 'PrivacySubscribe';
@@ -329,6 +330,9 @@ struct Index {
       }
     });
 
+    // 图标包云端自动恢复：检查云端是否有更新的备份，如有则静默恢复并合并
+    this.checkAndRestoreIconPacks();
+
     // [冷启动优化] FortiToken 证书文件从同步读取改为异步读取，避免阻塞主线程
     let cer_path = this.appCtx.filesDir + "/fmt.ks"
     fs.access(cer_path, fs.AccessModeType.EXIST).then((exist) => {
@@ -419,6 +423,14 @@ struct Index {
       TokenIconPacks.enabled_packs = AppPreference.loadEnabledPacks();
     }
     this.appCtx.eventHub.emit(EVENT_NAMES.ICON_PACK_CHANGED);
+  }
+
+  /**
+   * 图标包自动恢复入口，委托给 IconPackCloudBackup.checkAndAutoRestore()
+   * 内部通过状态机保证不会与备份/清理操作冲突
+   */
+  private async checkAndRestoreIconPacks(): Promise<void> {
+    await IconPackCloudBackup.getInstance().checkAndAutoRestore();
   }
 
   /**

--- a/entry/src/main/ets/pages/Index.ets
+++ b/entry/src/main/ets/pages/Index.ets
@@ -430,7 +430,11 @@ struct Index {
    * 内部通过状态机保证不会与备份/清理操作冲突
    */
   private async checkAndRestoreIconPacks(): Promise<void> {
-    await IconPackCloudBackup.getInstance().checkAndAutoRestore();
+    try {
+      await IconPackCloudBackup.getInstance().checkAndAutoRestore();
+    } catch (err) {
+      hilog.error(0xFF00, 'Index', `checkAndRestoreIconPacks failed: ${JSON.stringify(err)}`);
+    }
   }
 
   /**

--- a/entry/src/main/ets/pages/Index.ets
+++ b/entry/src/main/ets/pages/Index.ets
@@ -12,6 +12,7 @@ import lazy { FeedbackSheet } from '../pages/setting/FeedbackSheet'
 // [冷启动优化] NavDestination 子页面：仅在用户导航时触发评估
 import lazy { TokenCardConfigPage } from './TokenCardConfigPage'
 import lazy { TokenSortPage } from './TokenSortPage'
+import lazy { TokenSearchPage } from './TokenSearchPage'
 import { util, url } from '@kit.ArkTS';
 // [冷启动优化] 文件 I/O 仅在 deferredInit 中使用
 import lazy { fileIo as fs } from '@kit.CoreFileKit';
@@ -1357,6 +1358,8 @@ struct Index {
       TokenCardConfigPage()
     } else if (name === ROUTE_NAMES.TokenSortPage) {
       TokenSortPage({ scrollEffectType: this.currentScrollEffectType })
+    } else if (name === ROUTE_NAMES.TokenSearchPage) {
+      TokenSearchPage({ scrollEffectType: this.currentScrollEffectType })
     }
   }
 
@@ -1464,7 +1467,7 @@ struct Index {
                             icon: $r('sys.symbol.magnifyingglass'),
                             isEnabled: true,
                             action: () => {
-                              if (this.appCtx.eventHub != undefined) this.appCtx.eventHub.emit(EVENT_NAMES.TOGGLE_TOKEN_SEARCH);
+                              this.pageInfos.pushPathByName(ROUTE_NAMES.TokenSearchPage, null);
                             }
                           }
                         },

--- a/entry/src/main/ets/pages/ShowCloudBackupHistoryPage.ets
+++ b/entry/src/main/ets/pages/ShowCloudBackupHistoryPage.ets
@@ -189,14 +189,6 @@ export struct ShowCloudBackupHistoryPage {
               iconColor: $r('sys.color.icon_primary')
             }
           },
-          backgroundStyle: {
-            maskExtraHeight: 0
-          }
-        },
-        scrollEffectStyle: {
-          backgroundStyle: {
-            maskExtraHeight: 0
-          }
         },
         scrollEffectOpts: {
           enableScrollEffect: true,

--- a/entry/src/main/ets/pages/ShowCloudSyncDetailsPage.ets
+++ b/entry/src/main/ets/pages/ShowCloudSyncDetailsPage.ets
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 import { common, Want } from '@kit.AbilityKit';
-import { AppStorageV2, PromptAction, promptAction,LengthMetrics } from '@kit.ArkUI';
+import { AppStorageV2, promptAction, LengthMetrics } from '@kit.ArkUI';
 import { SettingItem } from '../components/SettingItem';
 import { AppPreference, SettingValue, PREF_KEYS, ROUTE_NAMES } from '../utils/AppPreference';
 import { SubItemButton } from '../components/SubItemButton';
@@ -30,6 +30,7 @@ import { hilog } from '@kit.PerformanceAnalysisKit';
 import { taskpool } from '@kit.ArkTS';
 import { checkCloudBackupRecords } from '../utils/CloudSyncTask';
 import { SyncTimeHelper } from '../utils/SyncTimeHelper';
+import { IconPackCloudBackup, IconPackSyncState } from '../utils/IconPackCloudBackup';
 
 const TAG = 'ShowCloudSyncDetailsPage';
 const DOMAIN = 0xFF00;
@@ -53,6 +54,12 @@ export struct ShowCloudSyncDetailsPage {
   @Local syncState: number = -1;
   @Local syncError: number = 0;
   @Local loadingText: ResourceStr = '';
+  @Local iconPackBackupExists: boolean = false;
+  @Local iconPackBackupCount: number = 0;
+  @Local iconPackBackupSize: number = 0;
+  @Local iconPackBackupTime: string = '';
+  @Local iconPackSyncState: number = IconPackSyncState.IDLE;
+  @Local iconPackSourceDevice: string = '';
   @Local window: AppWindowInfo = AppStorageV2.connect(AppWindowInfo) as AppWindowInfo;
   @Local appCtx: common.UIAbilityContext = AppStorage.get('appContext') as common.UIAbilityContext;
   private scroller: Scroller = new Scroller();
@@ -62,6 +69,7 @@ export struct ShowCloudSyncDetailsPage {
   private lastInitialSyncTime: number = 0;
   private readonly SYNC_COOLDOWN_MS: number = 60000;
   private readonly INITIAL_SYNC_COOLDOWN_MS: number = 600000;
+  private iconPackStatePollTimer: number = -1;
   private syncProgressCallback = (pg: cloudSync.SyncProgress) => {
     this.syncState = pg.state as number;
     this.syncError = pg.error as number;
@@ -86,6 +94,7 @@ export struct ShowCloudSyncDetailsPage {
       if (this.cloudSyncEnabled) {
         this.triggerInitialSyncAsync();
       }
+      this.loadIconPackBackupStatus();
     }
     finally {
       this.Is_loaded=false;
@@ -101,11 +110,66 @@ export struct ShowCloudSyncDetailsPage {
       let e = err as BusinessError;
       hilog.error(DOMAIN, TAG, `FileSync off progress failed: ${e.code} ${e.message}`);
     }
+    if (this.iconPackStatePollTimer >= 0) {
+      clearInterval(this.iconPackStatePollTimer);
+      this.iconPackStatePollTimer = -1;
+    }
   }
   /** 同步华为账号管理器的登录态到组件 @Local 变量，用于 UI 条件渲染 */
   private syncHuaweiAccountState(): void {
     const accountMgr = HuaweiAccountManager.getInstance();
     this.isHuaweiLoggedIn = accountMgr.userLogin;
+  }
+
+  private async loadIconPackBackupStatus(): Promise<void> {
+    const status = await IconPackCloudBackup.getInstance().getCloudBackupStatus();
+    this.iconPackBackupExists = status.exists;
+    this.iconPackBackupCount = status.packCount;
+    this.iconPackBackupSize = status.size;
+    this.iconPackBackupTime = status.lastTime;
+    this.iconPackSourceDevice = status.sourceDeviceName;
+    this.iconPackSyncState = IconPackCloudBackup.getInstance().getState();
+
+    // 启动轮询：每 2 秒检查状态机，非 IDLE 时刷新 UI
+    if (this.iconPackStatePollTimer < 0) {
+      this.iconPackStatePollTimer = setInterval(() => {
+        const newState = IconPackCloudBackup.getInstance().getState();
+        if (newState !== this.iconPackSyncState) {
+          this.iconPackSyncState = newState;
+          // 状态回到 IDLE 时刷新备份信息（操作完成）
+          if (newState === IconPackSyncState.IDLE) {
+            this.loadIconPackBackupStatus();
+          }
+        }
+      }, 2000) as number;
+    }
+  }
+
+  /** 将状态机枚举值映射为可读文本 */
+  private getIconPackSyncStateText(): ResourceStr {
+    switch (this.iconPackSyncState) {
+      case IconPackSyncState.BACKING_UP:
+        return $r('app.string.cloud_sync_icon_pack_state_backing_up');
+      case IconPackSyncState.RESTORING:
+        return $r('app.string.cloud_sync_icon_pack_state_restoring');
+      case IconPackSyncState.CLEARING:
+        return $r('app.string.cloud_sync_icon_pack_state_clearing');
+      case IconPackSyncState.CHECKING:
+        return $r('app.string.cloud_sync_icon_pack_state_checking');
+      default:
+        return '';
+    }
+  }
+
+  private isIconPackBusy(): boolean {
+    return this.iconPackSyncState !== IconPackSyncState.IDLE;
+  }
+
+  private formatFileSize(bytes: number): string {
+    if (bytes <= 0) return '0B';
+    if (bytes < 1024) return `${bytes}B`;
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`;
+    return `${(bytes / 1024 / 1024).toFixed(1)}MB`;
   }
 
   build() {
@@ -255,6 +319,87 @@ export struct ShowCloudSyncDetailsPage {
                 }
                 .padding({ left: $r('sys.float.padding_level8'), right: $r('sys.float.padding_level8') })
 
+                ListItem() {
+                  SettingItem({ title: $r('app.string.cloud_sync_icon_pack_title') }) {
+                    Row() {
+                      Text($r('app.string.cloud_sync_icon_pack_status'))
+                        .fontSize($r('sys.float.ohos_id_text_size_body2'))
+                        .fontColor($r('sys.color.ohos_id_color_text_secondary'))
+                        .fontWeight(FontWeight.Regular)
+                        .layoutWeight(1)
+                      if (this.isIconPackBusy()) {
+                        LoadingProgress()
+                          .width(16)
+                          .height(16)
+                          .margin({ right: 6 })
+                        Text(this.getIconPackSyncStateText())
+                          .fontSize($r('sys.float.ohos_id_text_size_body2'))
+                          .fontColor($r('sys.color.ohos_id_color_emphasize'))
+                          .fontWeight(FontWeight.Medium)
+                      } else {
+                        Text(this.getIconPackBackupStatusText())
+                          .fontSize($r('sys.float.ohos_id_text_size_body2'))
+                          .fontColor(this.iconPackBackupExists ?
+                            $r('sys.color.ohos_id_color_text_primary') :
+                            $r('sys.color.ohos_id_color_text_secondary'))
+                          .fontWeight(FontWeight.Medium)
+                      }
+                    }
+                    .width('100%')
+                    .padding($r('sys.float.padding_level8'))
+
+                    SubItemDivider()
+
+                    Row() {
+                      Text($r('app.string.cloud_sync_icon_pack_last_time'))
+                        .fontSize($r('sys.float.ohos_id_text_size_body2'))
+                        .fontColor($r('sys.color.ohos_id_color_text_secondary'))
+                        .fontWeight(FontWeight.Regular)
+                        .layoutWeight(1)
+                      Text((this.iconPackBackupTime != null && this.iconPackBackupTime !== '') ?
+                        this.iconPackBackupTime : $r('app.string.cloud_sync_never'))
+                        .fontSize($r('sys.float.ohos_id_text_size_body2'))
+                        .fontColor((this.iconPackBackupTime != null && this.iconPackBackupTime !== '') ?
+                          $r('sys.color.ohos_id_color_text_primary') :
+                          $r('sys.color.ohos_id_color_text_secondary'))
+                        .fontWeight(FontWeight.Medium)
+                    }
+                    .width('100%')
+                    .padding($r('sys.float.padding_level8'))
+
+                    SubItemDivider()
+
+                    Row() {
+                      Text($r('app.string.cloud_sync_icon_pack_source_device'))
+                        .fontSize($r('sys.float.ohos_id_text_size_body2'))
+                        .fontColor($r('sys.color.ohos_id_color_text_secondary'))
+                        .fontWeight(FontWeight.Regular)
+                        .layoutWeight(1)
+                      Text((this.iconPackSourceDevice !== null && this.iconPackSourceDevice !== '') ?
+                        this.iconPackSourceDevice : '-')
+                        .fontSize($r('sys.float.ohos_id_text_size_body2'))
+                        .fontColor((this.iconPackSourceDevice !== null && this.iconPackSourceDevice !== '') ?
+                          $r('sys.color.ohos_id_color_text_primary') :
+                          $r('sys.color.ohos_id_color_text_secondary'))
+                        .fontWeight(FontWeight.Medium)
+                    }
+                    .width('100%')
+                    .padding($r('sys.float.padding_level8'))
+
+                    SubItemDivider()
+
+                    Row() {
+                      Text($r('app.string.cloud_sync_icon_pack_hint'))
+                        .fontSize($r('sys.float.ohos_id_text_size_caption'))
+                        .fontColor($r('sys.color.ohos_id_color_text_secondary'))
+                        .layoutWeight(1)
+                    }
+                    .width('100%')
+                    .padding($r('sys.float.padding_level8'))
+                  }
+                }
+                .padding({ left: $r('sys.float.padding_level8'), right: $r('sys.float.padding_level8') })
+
 
 
                 ListItem() {
@@ -378,6 +523,18 @@ export struct ShowCloudSyncDetailsPage {
     .onReady((context: NavDestinationContext) => {
       this.pageInfos = context.pathStack;
     })
+  }
+
+  /** 图标包备份状态文本 */
+  private getIconPackBackupStatusText(): ResourceStr {
+    if (this.iconPackBackupCount === 0) {
+      return $r('app.string.cloud_sync_icon_pack_status_empty');
+    }
+    if (!this.iconPackBackupExists) {
+      return $r('app.string.cloud_sync_icon_pack_status_none');
+    }
+    const sizeStr = this.formatFileSize(this.iconPackBackupSize);
+    return `${this.iconPackBackupCount} ${$r('app.string.cloud_sync_icon_pack_status_done_suffix')} ${sizeStr}`;
   }
 
   /** FileSync 状态码 → i18n 文本映射（0=上传中, 1=上传失败, 2=下载中, 3=下载失败, 4=完成, 5=已停止） */

--- a/entry/src/main/ets/pages/ShowCloudSyncDetailsPage.ets
+++ b/entry/src/main/ets/pages/ShowCloudSyncDetailsPage.ets
@@ -533,8 +533,9 @@ export struct ShowCloudSyncDetailsPage {
     if (!this.iconPackBackupExists) {
       return $r('app.string.cloud_sync_icon_pack_status_none');
     }
+    const suffix = this.appCtx.resourceManager.getStringSync($r('app.string.cloud_sync_icon_pack_status_done_suffix').id);
     const sizeStr = this.formatFileSize(this.iconPackBackupSize);
-    return `${this.iconPackBackupCount} ${$r('app.string.cloud_sync_icon_pack_status_done_suffix')} ${sizeStr}`;
+    return `${this.iconPackBackupCount} ${suffix} ${sizeStr}`;
   }
 
   /** FileSync 状态码 → i18n 文本映射（0=上传中, 1=上传失败, 2=下载中, 3=下载失败, 4=完成, 5=已停止） */

--- a/entry/src/main/ets/pages/ShowCloudSyncDetailsPage.ets
+++ b/entry/src/main/ets/pages/ShowCloudSyncDetailsPage.ets
@@ -496,14 +496,6 @@ export struct ShowCloudSyncDetailsPage {
               iconColor: $r('sys.color.icon_primary')
             }
           },
-          backgroundStyle: {
-            maskExtraHeight: 0
-          }
-        },
-        scrollEffectStyle: {
-          backgroundStyle: {
-            maskExtraHeight: 0
-          }
         },
         scrollEffectOpts: {
           enableScrollEffect: true,

--- a/entry/src/main/ets/pages/ShowDataSyncDetailsPage.ets
+++ b/entry/src/main/ets/pages/ShowDataSyncDetailsPage.ets
@@ -155,14 +155,6 @@ export struct ShowDataSyncDetailsPage {
               iconColor: $r('sys.color.icon_primary')
             }
           },
-          backgroundStyle: {
-            maskExtraHeight: 0
-          }
-        },
-        scrollEffectStyle: {
-          backgroundStyle: {
-            maskExtraHeight: 0
-          }
         },
         scrollEffectOpts: {
           enableScrollEffect: true,

--- a/entry/src/main/ets/pages/TokenListPage.ets
+++ b/entry/src/main/ets/pages/TokenListPage.ets
@@ -252,14 +252,8 @@ export struct TokenListPage {
               }
             })
           }, (vm: TokenConfigVM) => vm.objid) // keyGenerator: objid 变化 = 组件重建
-
-          ListItem() {
-            Row()
-              .height(this.TabBarVisible ? (80 + this.appBottomAvoidHeight) : (20 + this.appBottomAvoidHeight))
-              .width('100%')
-          }
-          .selectable(false)
         }
+        .contentEndOffset(this.TabBarVisible ? (80 + this.appBottomAvoidHeight) : (20 + this.appBottomAvoidHeight))
         .alignListItem(ListItemAlign.Center)
         .lanes({ minLength: 400, maxLength: this.token_preference.app_appearance_item_max_width })
         .layoutWeight(1)

--- a/entry/src/main/ets/pages/TokenListPage.ets
+++ b/entry/src/main/ets/pages/TokenListPage.ets
@@ -9,7 +9,6 @@ import { TokenStore } from "../utils/TokenStore";
 import { convertToken2URI } from "../utils/TokenUtils";
 import { AppStorageV2, curves, window } from "@kit.ArkUI";
 import { AppWindowInfo } from "../entryability/EntryAbility";
-import { CommonConstants } from "../utils/CommonConstants";
 import { GenericDataSource } from "../utils/GenericDataSource";
 import { showSnackBar, SnackBarNotifyType } from "../utils/HdsSnackBarUtils";
 import { common } from "@kit.AbilityKit";
@@ -174,10 +173,6 @@ export struct TokenListPage {
           ListItemGroup() {
             ListItem() {
               Column() {
-                Row()
-                  .height(this.TabBarVisible ? CommonConstants.AVOID_TOP_BASE_HEIGHT + this.appTopAvoidHeight : this.appTopAvoidHeight)
-                  .width('100%')
-                
                 Stack({ alignContent: Alignment.End }) {
                   TextInput({
                     placeholder: $r('app.string.token_search_placeholder'),
@@ -208,7 +203,6 @@ export struct TokenListPage {
                   x: 0,
                   y: this.token_list_search_visible || this.token_list_search_enable ? 0 : -12
                 })
-                .clip(true)
               }
             }
           }
@@ -262,6 +256,7 @@ export struct TokenListPage {
         .chainAnimation(this.token_preference.app_appearance_chain_animation_enable)
         .scrollBar(BarState.Off)
         .edgeEffect(EdgeEffect.Spring, { alwaysEnabled: true })
+        .clip(false)
       }
       .alignItems(HorizontalAlign.Center)
     }

--- a/entry/src/main/ets/pages/TokenListPage.ets
+++ b/entry/src/main/ets/pages/TokenListPage.ets
@@ -7,7 +7,7 @@ import { AppPreference, TokenPreference, EVENT_NAMES, PREF_KEYS } from "../utils
 import { otpType, TokenConfig, TokenConfigVM } from "../utils/TokenConfig";
 import { TokenStore } from "../utils/TokenStore";
 import { convertToken2URI } from "../utils/TokenUtils";
-import { AppStorageV2, curves, window } from "@kit.ArkUI";
+import { AppStorageV2, window } from "@kit.ArkUI";
 import { AppWindowInfo } from "../entryability/EntryAbility";
 import { GenericDataSource } from "../utils/GenericDataSource";
 import { showSnackBar, SnackBarNotifyType } from "../utils/HdsSnackBarUtils";
@@ -46,34 +46,12 @@ export struct TokenListPage {
     this.dataSource.updateData(toVMs(monitor.value()?.now as TokenConfig[]));
   }
 
-  @Local token_list_search_result: TokenConfigVM[] = [];
-  @Local token_list_search_visible: boolean = false;
-  @Local token_list_search_enable: boolean = false;
-  @Local token_list_search_str: string = '';
-  @Local id_list: string[] = ['search_bar', 'search_blur_anchor'];
-
   private dialog_totp_config?: CustomDialogController;
   private dialog_forti_config?: CustomDialogController;
   private dialog_steam_config?: CustomDialogController;
   private dialog_qrcode?: CustomDialogController;
   private appCtx: common.UIAbilityContext = AppStorage.get('appContext') as common.UIAbilityContext;
-  private toggleSearchHandler: () => void = () => {};
   private onSingleTokenUpdatedHandler: (token: TokenConfig) => void = () => {};
-
-  async filterCurrentTokens(filter_word: string): Promise<void> {
-    if (filter_word.length === 0) {
-      this.token_list_search_enable = false;
-      this.dataSource.updateData(toVMs(this.Tokens));
-      return;
-    }
-    this.token_list_search_enable = true;
-    const lower_filter_word = filter_word.toLowerCase();
-    const filtered = this.Tokens.filter((token) => {
-      return token.TokenIssuer.toLowerCase().indexOf(lower_filter_word) >= 0 || token.TokenName.toLowerCase().indexOf(lower_filter_word) >= 0
-    });
-    this.token_list_search_result = toVMs(filtered);
-    this.dataSource.updateData(this.token_list_search_result);
-  }
 
   aboutToAppear(): void {
     this.dataSource = new GenericDataSource(toVMs(this.Tokens));
@@ -84,34 +62,8 @@ export struct TokenListPage {
     this.appCtx.eventHub?.on(EVENT_NAMES.TOKEN_SINGLE_UPDATED, this.onSingleTokenUpdatedHandler);
   }
 
-  onDidBuild(): void {
-    this.toggleSearchHandler = () => { this.toggleTokenSearchByTitleBar() };
-    this.appCtx.eventHub?.on(EVENT_NAMES.TOGGLE_TOKEN_SEARCH, this.toggleSearchHandler);
-  }
-
   aboutToDisappear(): void {
-    this.appCtx.eventHub?.off(EVENT_NAMES.TOGGLE_TOKEN_SEARCH, this.toggleSearchHandler);
     this.appCtx.eventHub?.off(EVENT_NAMES.TOKEN_SINGLE_UPDATED, this.onSingleTokenUpdatedHandler);
-  }
-
-  private toggleTokenSearchByTitleBar(): void {
-    const nextVisible = !this.token_list_search_visible;
-    this.window.uiContext?.animateTo({ duration: 250, curve: curves.springMotion() }, () => {
-      this.token_list_search_visible = nextVisible;
-      if (!this.token_list_search_visible) {
-        this.token_list_search_str = '';
-        this.token_list_search_enable = false;
-      }
-    })
-    if (nextVisible) {
-      setTimeout(() => {
-        focusControl.requestFocus(this.id_list[0])
-      }, 180)
-    } else {
-      setTimeout(() => {
-        focusControl.requestFocus(this.id_list[1])
-      }, 100)
-    }
   }
 
   private async updateSingleToken(conf: TokenConfig, toast: boolean): Promise<boolean> {
@@ -148,17 +100,9 @@ export struct TokenListPage {
 
   build() {
     Stack({ alignContent: Alignment.Bottom }) {
-      Button('')
-        .id(this.id_list[1])
-        .focusable(true)
-        .width(1)
-        .height(1)
-        .opacity(0)
-        .position({ x: 0, y: 0 })
       if (this.Tokens.length === 0) {
         Row() {
-          Text(this.token_list_search_enable ? $r('app.string.app_token_list_search_msg') :
-          $r('app.string.app_guide_msg'))
+          Text($r('app.string.app_guide_msg'))
             .textAlign(TextAlign.Center)
             .fontSize(20)
             .width('100%')
@@ -170,43 +114,6 @@ export struct TokenListPage {
       }
       Column() {
         List({ space: this.token_preference.app_appearance_item_space, initialIndex: 0, scroller: this.listScroller }) {
-          ListItemGroup() {
-            ListItem() {
-              Column() {
-                Stack({ alignContent: Alignment.End }) {
-                  TextInput({
-                    placeholder: $r('app.string.token_search_placeholder'),
-                    text: this.token_list_search_str
-                  })
-                    .id(this.id_list[0])
-                    .onChange((value) => {
-                      this.token_list_search_str = value;
-                      this.filterCurrentTokens(this.token_list_search_str);
-                    })
-                    .onSubmit(() => {
-                      this.filterCurrentTokens(this.token_list_search_str);
-                    })
-                  SymbolGlyph($r('sys.symbol.xmark'))
-                    .fontSize(20)
-                    .fontWeight(FontWeight.Medium)
-                    .fontColor([$r('app.color.item_fg')])
-                    .padding({ right: 10 })
-                    .onClick(() => {
-                      this.toggleTokenSearchByTitleBar();
-                    })
-                }
-                .padding({ left: 10, right: 10, top: this.token_list_search_visible || this.token_list_search_enable ? 10 : 0 })
-                .width('100%')
-                .height(this.token_list_search_visible || this.token_list_search_enable ? 56 : 0)
-                .opacity(this.token_list_search_visible || this.token_list_search_enable ? 1 : 0)
-                .translate({
-                  x: 0,
-                  y: this.token_list_search_visible || this.token_list_search_enable ? 0 : -12
-                })
-              }
-            }
-          }
-
           // key = vm.objid：变更 objid 后 LazyForEach 视为"新数据"，销毁旧组件并创建新实例
           LazyForEach(this.dataSource, (vm: TokenConfigVM) => {
             ListItem() {

--- a/entry/src/main/ets/pages/TokenSearchPage.ets
+++ b/entry/src/main/ets/pages/TokenSearchPage.ets
@@ -1,0 +1,349 @@
+import { TokenItem } from "../components/TokenItem";
+import { FortiConfigDialog } from "../dialogs/FortiConfigDialog";
+import { TOTPConfigDialog } from "../dialogs/OTPConfigDialog";
+import { QRCodeDialog } from "../dialogs/QRCodeDialog";
+import { SteamConfigDialog } from "../dialogs/SteamConfigDialog";
+import { AppPreference, TokenPreference, EVENT_NAMES, PREF_KEYS } from "../utils/AppPreference";
+import { otpType, TokenConfig, TokenConfigVM } from "../utils/TokenConfig";
+import { TokenStore } from "../utils/TokenStore";
+import { convertToken2URI } from "../utils/TokenUtils";
+import { AppStorageV2 } from "@kit.ArkUI";
+import { AppWindowInfo } from "../entryability/EntryAbility";
+import { GenericDataSource } from "../utils/GenericDataSource";
+import { showSnackBar, SnackBarNotifyType } from "../utils/HdsSnackBarUtils";
+import { common } from "@kit.AbilityKit";
+import { hilog } from "@kit.PerformanceAnalysisKit";
+import {
+  BottomBuilderShowType,
+  HdsNavDestination,
+  HdsNavDestinationTitleMode,
+  ScrollEffectType,
+  hdsMaterial
+} from "@kit.UIDesignKit";
+import { CommonConstants } from "../utils/CommonConstants";
+
+let tkStore = TokenStore.getInstance();
+
+function toVMs(tokens: TokenConfig[]): TokenConfigVM[] {
+  return tokens.map(t => new TokenConfigVM(t));
+}
+
+@Preview
+@ComponentV2
+export struct TokenSearchPage {
+  @Require @Param scrollEffectType: ScrollEffectType = ScrollEffectType.IMMERSIVE_GRADIENT_BLUR;
+  @Local token_preference: TokenPreference = AppStorageV2.connect(TokenPreference) as TokenPreference;
+  @Local window: AppWindowInfo = AppStorageV2.connect(AppWindowInfo) as AppWindowInfo;
+  @Local tokens: TokenConfig[] = [];
+  @Local dataSource: GenericDataSource<TokenConfigVM> = new GenericDataSource([]);
+  @Local tokenSearchText: string = '';
+  @Local token_copy_guide_popup: boolean = false;
+
+  private searchListScroller: Scroller = new Scroller();
+  private dialog_totp_config?: CustomDialogController;
+  private dialog_forti_config?: CustomDialogController;
+  private dialog_steam_config?: CustomDialogController;
+  private dialog_qrcode?: CustomDialogController;
+  private appCtx: common.UIAbilityContext = AppStorage.get('appContext') as common.UIAbilityContext;
+  private onTokenChangedHandler: () => void = () => {};
+  private onSingleTokenUpdatedHandler: (token: TokenConfig) => void = () => {};
+
+  aboutToAppear(): void {
+    this.onTokenChangedHandler = () => this.loadTokens();
+    this.onSingleTokenUpdatedHandler = (token: TokenConfig) => this.handleTokenSingleUpdated(token);
+    this.appCtx.eventHub?.on(EVENT_NAMES.TOKEN_CHANGED, this.onTokenChangedHandler);
+    this.appCtx.eventHub?.on(EVENT_NAMES.TOKEN_SINGLE_UPDATED, this.onSingleTokenUpdatedHandler);
+    if (AppPreference.getPreference(PREF_KEYS.SHOW_GUIDE_TIPS) as boolean) {
+      this.token_copy_guide_popup = true;
+    }
+    this.loadTokens();
+  }
+
+  aboutToDisappear(): void {
+    this.appCtx.eventHub?.off(EVENT_NAMES.TOKEN_CHANGED, this.onTokenChangedHandler);
+    this.appCtx.eventHub?.off(EVENT_NAMES.TOKEN_SINGLE_UPDATED, this.onSingleTokenUpdatedHandler);
+  }
+
+  private async loadTokens(): Promise<void> {
+    this.tokens = await tkStore.getTokens();
+    this.filterCurrentTokens(this.tokenSearchText);
+  }
+
+  private filterCurrentTokens(filterWord: string): void {
+    const keyword = filterWord.trim().toLowerCase();
+    if (keyword.length === 0) {
+      this.dataSource.updateData(toVMs(this.tokens));
+      return;
+    }
+    const filtered = this.tokens.filter((token) => {
+      return token.TokenIssuer.toLowerCase().indexOf(keyword) >= 0 ||
+        token.TokenName.toLowerCase().indexOf(keyword) >= 0;
+    });
+    this.dataSource.updateData(toVMs(filtered));
+  }
+
+  private handleTokenSingleUpdated(token: TokenConfig): void {
+    const tokenIndex = this.tokens.findIndex((item: TokenConfig) => item.TokenUUID === token.TokenUUID);
+    if (tokenIndex >= 0) {
+      this.tokens[tokenIndex] = token;
+    }
+    const index = this.dataSource.findIndex((vm: TokenConfigVM) => vm.config.TokenUUID === token.TokenUUID);
+    if (index >= 0) {
+      const vm = this.dataSource.getData(index);
+      vm.config = token;
+      vm.refreshObjId();
+      this.dataSource.updateItem(index, vm);
+    }
+  }
+
+  private async updateSingleToken(conf: TokenConfig, toast: boolean): Promise<boolean> {
+    try {
+      await tkStore.updateToken(conf);
+      if (toast) {
+        showSnackBar($r('app.string.toast_token_update', conf.TokenIssuer, conf.TokenName), SnackBarNotifyType.SUCCESS);
+      }
+      return true;
+    } catch (e) {
+      hilog.error(0, 'TokenSearchPage', `updateSingleToken failed: ${e}`);
+      return false;
+    }
+  }
+
+  @Builder
+  SearchBottomBuilder() {
+    Column() {
+      Search({
+        placeholder: $r('app.string.token_search_placeholder'),
+        value: this.tokenSearchText
+      })
+        .width('100%')
+        .height(40)
+        .onChange((value: string) => {
+          this.tokenSearchText = value;
+          this.filterCurrentTokens(value);
+        })
+        .onSubmit((value: string) => {
+          this.tokenSearchText = value;
+          this.filterCurrentTokens(value);
+        })
+    }
+    .width('100%')
+    .padding({ left: 16, right: 16 })
+  }
+
+  build() {
+    HdsNavDestination() {
+      Column() {
+        List({ space: this.token_preference.app_appearance_item_space, scroller: this.searchListScroller }) {
+          if (this.dataSource.totalCount() === 0) {
+            ListItem() {
+              Text(this.tokenSearchText.trim().length > 0 ? $r('app.string.app_token_list_search_msg') :
+              $r('app.string.app_guide_msg'))
+                .textAlign(TextAlign.Center)
+                .fontSize(20)
+                .fontColor($r('sys.color.font_secondary'))
+                .width('100%')
+                .padding({ top: 80 })
+            }
+          }
+
+          LazyForEach(this.dataSource, (vm: TokenConfigVM) => {
+            ListItem() {
+              TokenItem({
+                Config: vm.config,
+                Update: async (conf_new): Promise<boolean> => {
+                  return await this.updateSingleToken(conf_new, false);
+                }
+              })
+                .bindPopup(this.token_copy_guide_popup && vm.config.TokenUUID === this.dataSource.getData(0)?.config.TokenUUID, {
+                  placement: Placement.Left,
+                  message: this.getUIContext().getHostContext()?.resourceManager
+                    .getStringSync($r('app.string.token_copy_guide_popup').id),
+                  onStateChange: (e) => {
+                    if (!e.isVisible) {
+                      this.token_copy_guide_popup = false;
+                    }
+                  },
+                  primaryButton: {
+                    value: this.getUIContext().getHostContext()?.resourceManager
+                      .getStringSync($r('app.string.token_copy_guide_popup_Confirm').id),
+                    action: () => {
+                      if (AppPreference.getPreference(PREF_KEYS.SHOW_GUIDE_TIPS) as boolean) {
+                        AppPreference.setPreference(PREF_KEYS.SHOW_GUIDE_TIPS, false);
+                      }
+                      this.token_copy_guide_popup = false;
+                    }
+                  }
+                })
+            }
+            .swipeAction({
+              end: {
+                builder: () => {
+                  this.TokenItemSwipeEnd(vm);
+                },
+              }
+            })
+          }, (vm: TokenConfigVM) => vm.objid)
+        }
+        .clip(false)
+        .alignListItem(ListItemAlign.Center)
+        .lanes({ minLength: 400, maxLength: this.token_preference.app_appearance_item_max_width })
+        .layoutWeight(1)
+        .width('100%')
+        .height('100%')
+        .scrollBar(BarState.Off)
+        .edgeEffect(EdgeEffect.Spring, { alwaysEnabled: true })
+        .contentStartOffset(this.window.AvoidTopHeight + CommonConstants.AVOID_TOP_WITH_SEARCHBAR_HEIGHT)
+        .contentEndOffset(this.window.AvoidBottomHeight)
+      }
+      .backgroundColor($r('app.color.window_background'))
+      .width('100%')
+      .height('100%')
+    }
+    .titleMode(HdsNavDestinationTitleMode.MINI)
+    .titleBar({
+      avoidLayoutSafeArea: true,
+      style: {
+        originalStyle: {
+          contentStyle: {
+            titleStyle: {
+              mainTitleColor: $r('sys.color.font_primary'),
+            },
+            backIconStyle: {
+              iconColor: $r('sys.color.icon_primary')
+            }
+          },
+        },
+        scrollEffectOpts: {
+          enableScrollEffect: true,
+          scrollEffectType: this.scrollEffectType,
+        },
+        systemMaterialEffect: {
+          materialType: hdsMaterial.MaterialType.ADAPTIVE,
+          materialLevel: hdsMaterial.MaterialLevel.ADAPTIVE
+        }
+      },
+      content: {
+        title: {
+          mainTitle: $r('app.string.app_ua_search_token'),
+        },
+        bottomBuilder: {
+          builder: (): void => this.SearchBottomBuilder(),
+          height: 56,
+          showType: BottomBuilderShowType.DIRECTLY_SHOW,
+        },
+      }
+    })
+    .bindToScrollable([this.searchListScroller])
+  }
+
+  showQRCodeDialog(conf: TokenConfig): void {
+    this.dialog_qrcode = new CustomDialogController({
+      builder: QRCodeDialog({
+        content: convertToken2URI(conf),
+        winSize: this.window.Size
+      })
+    });
+    this.dialog_qrcode.open();
+  }
+
+  @Builder
+  TokenItemSwipeEnd(vm: TokenConfigVM) {
+    Row({ space: 10 }) {
+      Button({ type: ButtonType.Circle }) {
+        Text() {
+          SymbolSpan($r('sys.symbol.qrcode'))
+            .fontSize(30)
+            .fontWeight(FontWeight.Medium)
+            .fontColor([Color.White])
+        }
+      }
+      .backgroundColor(Color.Orange)
+      .padding(10)
+      .onClick(() => {
+        this.showQRCodeDialog(vm.config);
+      })
+
+      Button({ type: ButtonType.Circle }) {
+        Text() {
+          SymbolSpan($r('sys.symbol.square_and_pencil_fill'))
+            .fontSize(30)
+            .fontWeight(FontWeight.Medium)
+            .fontColor([Color.White])
+        }
+      }
+      .backgroundColor(Color.Gray)
+      .padding(10)
+      .onClick(() => {
+        if (vm.config.TokenType === otpType.TOTP || vm.config.TokenType === otpType.HOTP ||
+          vm.config.TokenType === undefined) {
+          this.dialog_totp_config = new CustomDialogController({
+            builder: TOTPConfigDialog({
+              conf_json: JSON.stringify(vm.config),
+              confirm: async (new_conf): Promise<boolean> => {
+                const md: TokenConfig = JSON.parse(new_conf);
+                return await this.updateSingleToken(md, true);
+              }
+            })
+          })
+          this.dialog_totp_config.open()
+        } else if (vm.config.TokenType === otpType.Forti) {
+          this.dialog_forti_config = new CustomDialogController({
+            builder: FortiConfigDialog({
+              conf_json: JSON.stringify(vm.config),
+              confirm: async (new_conf): Promise<boolean> => {
+                const md: TokenConfig = JSON.parse(new_conf);
+                return await this.updateSingleToken(md, true);
+              }
+            })
+          })
+          this.dialog_forti_config.open()
+        } else if (vm.config.TokenType === otpType.Steam) {
+          this.dialog_steam_config = new CustomDialogController({
+            builder: SteamConfigDialog({
+              conf_json: JSON.stringify(vm.config),
+              confirm: async (new_conf): Promise<boolean> => {
+                const md: TokenConfig = JSON.parse(new_conf);
+                return await this.updateSingleToken(md, true);
+              }
+            })
+          })
+          this.dialog_steam_config.open()
+        }
+      })
+
+      Button({ type: ButtonType.Circle }) {
+        Text() {
+          SymbolSpan($r('sys.symbol.trash_fill'))
+            .fontSize(30)
+            .fontWeight(FontWeight.Medium)
+            .fontColor([Color.White])
+        }
+      }
+      .backgroundColor(Color.Red)
+      .padding(10)
+      .onClick(async () => {
+        AlertDialog.show({
+          message: $r('app.string.alert_remove_confirm_msg', vm.config.TokenName),
+          autoCancel: true,
+          alignment: DialogAlignment.Center,
+          primaryButton: {
+            defaultFocus: false,
+            value: $r('app.string.dialog_btn_cancel'),
+            action: () => {
+              return;
+            }
+          },
+          secondaryButton: {
+            value: $r('app.string.dialog_btn_confirm'),
+            fontColor: Color.Red,
+            action: async () => {
+              tkStore.deleteToken(vm.config.TokenUUID);
+            }
+          }
+        })
+      })
+    }
+    .margin({ left: 10 })
+  }
+}

--- a/entry/src/main/ets/pages/TokenSortPage.ets
+++ b/entry/src/main/ets/pages/TokenSortPage.ets
@@ -83,6 +83,7 @@ export struct TokenSortPage {
         .height('100%')
         .scrollBar(BarState.Off)
         .edgeEffect(EdgeEffect.Spring, { alwaysEnabled: true })
+        .contentStartOffset(this.window.AvoidTopHeight + CommonConstants.AVOID_TOP_BASE_HEIGHT)
         .contentEndOffset(this.window.AvoidBottomHeight)
       }
       .backgroundColor($r('app.color.window_background'))
@@ -92,30 +93,20 @@ export struct TokenSortPage {
     .titleMode(HdsNavDestinationTitleMode.MINI)
     .titleBar({
       avoidLayoutSafeArea: true,
-      enableComponentSafeArea: true,
       style: {
         originalStyle: {
           contentStyle: {
             titleStyle: {
               mainTitleColor: $r('sys.color.font_primary'),
-              subTitleColor: $r('sys.color.font_secondary')
             },
             backIconStyle: {
               iconColor: $r('sys.color.icon_primary')
             }
           },
-          backgroundStyle: {
-            maskExtraHeight: 0
-          }
-        },
-        scrollEffectStyle: {
-          backgroundStyle: {
-            maskExtraHeight: 0
-          }
         },
         scrollEffectOpts: {
           enableScrollEffect: true,
-          scrollEffectType: this.scrollEffectType
+          scrollEffectType: this.scrollEffectType,
         },
         systemMaterialEffect: {
           materialType: hdsMaterial.MaterialType.ADAPTIVE,

--- a/entry/src/main/ets/pages/TokenSortPage.ets
+++ b/entry/src/main/ets/pages/TokenSortPage.ets
@@ -51,12 +51,6 @@ export struct TokenSortPage {
     HdsNavDestination() {
       Column() {
         List({ space: this.token_preference.app_appearance_item_space, scroller: this.sortListScroller }) {
-          // 顶部避让区域 — 用 ListItemGroup 确保多 lane 布局中跨整行
-          ListItemGroup() {
-            ListItem()
-              .height(CommonConstants.AVOID_TOP_BASE_HEIGHT + this.window.AvoidTopHeight)
-          }
-
           LazyForEach(this.dataSource, (token: TokenConfig, index: number) => {
             ListItem() {
               TokenItem({
@@ -81,10 +75,12 @@ export struct TokenSortPage {
             })
 
         }
+        .clip(false)
         .alignListItem(ListItemAlign.Center)
         .lanes({ minLength: 400, maxLength: this.token_preference.app_appearance_item_max_width })
         .layoutWeight(1)
         .width('100%')
+        .height('100%')
         .scrollBar(BarState.Off)
         .edgeEffect(EdgeEffect.Spring, { alwaysEnabled: true })
         .contentEndOffset(this.window.AvoidBottomHeight)
@@ -96,6 +92,7 @@ export struct TokenSortPage {
     .titleMode(HdsNavDestinationTitleMode.MINI)
     .titleBar({
       avoidLayoutSafeArea: true,
+      enableComponentSafeArea: true,
       style: {
         originalStyle: {
           contentStyle: {

--- a/entry/src/main/ets/pages/WebPage.ets
+++ b/entry/src/main/ets/pages/WebPage.ets
@@ -28,11 +28,11 @@ export struct WebPage {
           .darkMode(WebDarkMode.Auto)
           .domStorageAccess(true)
           .zoomAccess(true)
-          .fileAccess(true)
           .mixedMode(MixedMode.All)
           .cacheMode(CacheMode.Default)
           .javaScriptAccess(true)
           .width(CommonConstants.FULL_PERCENT)
+          .height(CommonConstants.FULL_PERCENT)
       }
       .width(CommonConstants.FULL_PERCENT)
       .height(CommonConstants.FULL_PERCENT)
@@ -52,14 +52,6 @@ export struct WebPage {
               iconColor: $r('sys.color.icon_primary')
             }
           },
-          backgroundStyle: {
-            maskExtraHeight: 0
-          }
-        },
-        scrollEffectStyle: {
-          backgroundStyle: {
-            maskExtraHeight: 0
-          }
         },
         systemMaterialEffect: {
           materialType: hdsMaterial.MaterialType.ADAPTIVE,

--- a/entry/src/main/ets/pages/setting/AboutSheet.ets
+++ b/entry/src/main/ets/pages/setting/AboutSheet.ets
@@ -5,7 +5,6 @@ import { AppStorageV2, curves } from '@kit.ArkUI';
 import { showSnackBar, SnackBarNotifyType } from '../../utils/HdsSnackBarUtils';
 import { AppPreference, PREF_KEYS } from '../../utils/AppPreference';
 import { hdsMaterial, HdsNavigation, HdsNavigationTitleMode, ScrollEffectType } from '@kit.UIDesignKit';
-import { CommonConstants } from '../../utils/CommonConstants';
 
 @Preview
 @ComponentV2
@@ -39,9 +38,6 @@ export struct AboutSheet {
     Column() {
       HdsNavigation() {
         List({ scroller: this.sheetScroller, space: 10 }) {
-          ListItem()
-            .height(CommonConstants.AVOID_TOP_BASE_HEIGHT)
-
           ListItem() {
             SettingItem({ title: "" }) {
               Text(this.str_about_app)
@@ -90,15 +86,8 @@ export struct AboutSheet {
             }
             .padding({ left: 10, right: 10 })
           }
-
-          ListItemGroup() {
-            ListItem() {
-              Row()
-                .width('100%')
-                .height(60)
-            }
-          }
         }
+        .clip(false)
         .width('100%')
         .height('100%')
         .scrollBar(BarState.Off)
@@ -110,6 +99,7 @@ export struct AboutSheet {
       .bindToScrollable([this.sheetScroller])
       .titleMode(HdsNavigationTitleMode.MODAL)
       .titleBar({
+        enableComponentSafeArea: true,
         style: {
           originalStyle: {
             contentStyle: {
@@ -121,14 +111,6 @@ export struct AboutSheet {
                 iconColor: $r('sys.color.icon_primary')
               }
             },
-            backgroundStyle: {
-              maskExtraHeight: 0
-            }
-          },
-          scrollEffectStyle: {
-            backgroundStyle: {
-              maskExtraHeight: 0
-            }
           },
           scrollEffectOpts: {
             enableScrollEffect: true,

--- a/entry/src/main/ets/pages/setting/AgreementSheet.ets
+++ b/entry/src/main/ets/pages/setting/AgreementSheet.ets
@@ -5,7 +5,6 @@ import { throttle } from '../../utils/UiUtils';
 import { ROUTE_NAMES } from '../../utils/AppPreference';
 import { WebPage, WebPageParams } from '../WebPage';
 import { hdsMaterial, HdsNavigation, HdsNavigationTitleMode, ScrollEffectType } from '@kit.UIDesignKit';
-import { CommonConstants } from '../../utils/CommonConstants';
 
 @Preview
 @ComponentV2
@@ -26,9 +25,6 @@ export struct AgreementSheet {
       HdsNavigation(this.pageInfos) {
         Column() {
           List({ scroller: this.sheetScroller, space: 10 }) {
-            ListItem()
-              .height(CommonConstants.AVOID_TOP_BASE_HEIGHT)
-
             ListItem() {
               SettingItem({ title: "" }) {
                 SubItemButton({ symbol: $r("sys.symbol.person_shield"), text: $r('app.string.privacy_statement') })
@@ -55,6 +51,7 @@ export struct AgreementSheet {
             }
             .padding({ left: 10, right: 10 })
           }
+          .clip(false)
           .width('100%')
           .height('100%')
           .scrollBar(BarState.Off)
@@ -74,6 +71,7 @@ export struct AgreementSheet {
       .bindToScrollable([this.sheetScroller])
       .titleMode(HdsNavigationTitleMode.MODAL)
       .titleBar({
+        enableComponentSafeArea: true,
         style: {
           originalStyle: {
             contentStyle: {
@@ -85,14 +83,6 @@ export struct AgreementSheet {
                 iconColor: $r('sys.color.icon_primary')
               }
             },
-            backgroundStyle: {
-              maskExtraHeight: 0
-            }
-          },
-          scrollEffectStyle: {
-            backgroundStyle: {
-              maskExtraHeight: 0
-            }
           },
           scrollEffectOpts: {
             enableScrollEffect: true,

--- a/entry/src/main/ets/pages/setting/AppearanceSheet.ets
+++ b/entry/src/main/ets/pages/setting/AppearanceSheet.ets
@@ -14,7 +14,6 @@ import { common, ConfigurationConstant } from '@kit.AbilityKit';
 import { throttle } from '../../utils/UiUtils';
 import { AppearancePage } from '../AppearancePage';
 import { hdsMaterial, HdsNavigation, HdsNavigationTitleMode, ScrollEffectType } from '@kit.UIDesignKit';
-import { CommonConstants } from '../../utils/CommonConstants';
 
 @Preview
 @ComponentV2
@@ -39,9 +38,6 @@ export struct AppearanceSheet {
       HdsNavigation(this.pageInfos) {
         Column() {
           List({ scroller: this.sheetScroller, space: 10 }) {
-            ListItem()
-              .height(CommonConstants.AVOID_TOP_BASE_HEIGHT)
-
             ListItem() {
               SettingItem({ title: "" }) {
                 SubItemToggle({
@@ -129,6 +125,7 @@ export struct AppearanceSheet {
             }
             .padding({ left: 10, right: 10 })
           }
+          .clip(false)
           .width('100%')
           .height('100%')
           .scrollBar(BarState.Off)
@@ -145,6 +142,7 @@ export struct AppearanceSheet {
       .bindToScrollable([this.sheetScroller])
       .titleMode(HdsNavigationTitleMode.MODAL)
       .titleBar({
+        enableComponentSafeArea: true,
         style: {
           originalStyle: {
             contentStyle: {
@@ -156,14 +154,6 @@ export struct AppearanceSheet {
                 iconColor: $r('sys.color.icon_primary')
               }
             },
-            backgroundStyle: {
-              maskExtraHeight: 0
-            }
-          },
-          scrollEffectStyle: {
-            backgroundStyle: {
-              maskExtraHeight: 0
-            }
           },
           scrollEffectOpts: {
             enableScrollEffect: true,

--- a/entry/src/main/ets/pages/setting/BackupAndMigrationSheet.ets
+++ b/entry/src/main/ets/pages/setting/BackupAndMigrationSheet.ets
@@ -18,7 +18,6 @@ import { ShowCloudSyncDetailsPage } from '../ShowCloudSyncDetailsPage';
 import { ShowCloudBackupHistoryPage } from '../ShowCloudBackupHistoryPage';
 import { HuaweiAccountManager } from '../../utils/HuaweiAccountManager';
 import { hdsMaterial, HdsNavigation, HdsNavigationTitleMode, ScrollEffectType } from '@kit.UIDesignKit';
-import { CommonConstants } from '../../utils/CommonConstants';
 import { TokenImporterRegistry, TokenImporter } from '../../utils/importers/TokenImporter';
 import { URIConfigDialog } from '../../dialogs/URIConfigDialog';
 
@@ -240,9 +239,6 @@ export struct BackupAndMigrationSheet {
       HdsNavigation(this.pageInfos) {
         Column({ space: LengthMetrics.vp(12).value }) {
           List({ scroller: this.sheetScroller, space: 10 }) {
-            ListItem()
-              .height(CommonConstants.AVOID_TOP_BASE_HEIGHT)
-
             ListItem() {
               SettingItem({ title: $r('app.string.setting_backup') }) {
                 SubItemButton({
@@ -364,7 +360,9 @@ export struct BackupAndMigrationSheet {
             }
             .padding({ left: 10, right: 10 })
           }
+          .clip(false)
           .width('100%')
+          .height('100%')
           .layoutWeight(1)
           .scrollBar(BarState.Off)
           .edgeEffect(EdgeEffect.Spring, { alwaysEnabled: true })
@@ -382,6 +380,7 @@ export struct BackupAndMigrationSheet {
       .bindToScrollable([this.sheetScroller])
       .titleMode(HdsNavigationTitleMode.MODAL)
       .titleBar({
+        enableComponentSafeArea: true,
         style: {
           originalStyle: {
             contentStyle: {
@@ -393,14 +392,6 @@ export struct BackupAndMigrationSheet {
                 iconColor: $r('sys.color.icon_primary')
               }
             },
-            backgroundStyle: {
-              maskExtraHeight: 0
-            }
-          },
-          scrollEffectStyle: {
-            backgroundStyle: {
-              maskExtraHeight: 0
-            }
           },
           scrollEffectOpts: {
             enableScrollEffect: true,

--- a/entry/src/main/ets/pages/setting/DataSyncSheet.ets
+++ b/entry/src/main/ets/pages/setting/DataSyncSheet.ets
@@ -10,7 +10,6 @@ import { PermissionManager } from '../../utils/PermissionManager';
 import { throttle } from '../../utils/UiUtils';
 import { ShowDataSyncDetailsPage } from '../ShowDataSyncDetailsPage';
 import { hdsMaterial, HdsNavigation, HdsNavigationTitleMode, ScrollEffectType } from '@kit.UIDesignKit';
-import { CommonConstants } from '../../utils/CommonConstants';
 
 @Preview
 @ComponentV2
@@ -50,9 +49,6 @@ export struct DataSyncSheet {
       HdsNavigation(this.pageInfos) {
         Column() {
           List({ scroller: this.sheetScroller, space: 10 }) {
-            ListItem()
-              .height(CommonConstants.AVOID_TOP_BASE_HEIGHT)
-
             ListItem() {
               SettingItem({ title: "" }) {
                 SubItemToggle({
@@ -82,6 +78,7 @@ export struct DataSyncSheet {
             }
             .padding({ left: 10, right: 10 })
           }
+          .clip(false)
           .width('100%')
           .height('100%')
           .scrollBar(BarState.Off)
@@ -101,6 +98,7 @@ export struct DataSyncSheet {
       .bindToScrollable([this.sheetScroller])
       .titleMode(HdsNavigationTitleMode.MODAL)
       .titleBar({
+        enableComponentSafeArea: true,
         style: {
           originalStyle: {
             contentStyle: {
@@ -112,14 +110,6 @@ export struct DataSyncSheet {
                 iconColor: $r('sys.color.icon_primary')
               }
             },
-            backgroundStyle: {
-              maskExtraHeight: 0
-            }
-          },
-          scrollEffectStyle: {
-            backgroundStyle: {
-              maskExtraHeight: 0
-            }
           },
           scrollEffectOpts: {
             enableScrollEffect: true,

--- a/entry/src/main/ets/pages/setting/FeedbackSheet.ets
+++ b/entry/src/main/ets/pages/setting/FeedbackSheet.ets
@@ -5,7 +5,6 @@ import { throttle, startBrowsableAbility } from '../../utils/UiUtils';
 import { ROUTE_NAMES, EXTERNAL_URLS } from '../../utils/AppPreference';
 import { WebPage, WebPageParams } from '../WebPage';
 import { hdsMaterial, HdsNavigation, HdsNavigationTitleMode, ScrollEffectType } from '@kit.UIDesignKit';
-import { CommonConstants } from '../../utils/CommonConstants';
 import { SubItemDivider } from '../../components/SubItemDivider';
 
 @Preview
@@ -28,9 +27,6 @@ export struct FeedbackSheet {
       HdsNavigation(this.pageInfos) {
         Column() {
           List({ scroller: this.sheetScroller, space: 10 }) {
-            ListItem()
-              .height(CommonConstants.AVOID_TOP_BASE_HEIGHT)
-
             ListItem() {
               SettingItem({ title: "" }) {
                 SubItemButton({
@@ -65,6 +61,7 @@ export struct FeedbackSheet {
             }
             .padding({ left: 10, right: 10 })
           }
+          .clip(false)
           .width('100%')
           .height('100%')
           .scrollBar(BarState.Off)
@@ -84,6 +81,7 @@ export struct FeedbackSheet {
       .bindToScrollable([this.sheetScroller])
       .titleMode(HdsNavigationTitleMode.MODAL)
       .titleBar({
+        enableComponentSafeArea: true,
         style: {
           originalStyle: {
             contentStyle: {
@@ -92,14 +90,6 @@ export struct FeedbackSheet {
                 subTitleColor: $r('sys.color.font_secondary')
               }
             },
-            backgroundStyle: {
-              maskExtraHeight: 0
-            }
-          },
-          scrollEffectStyle: {
-            backgroundStyle: {
-              maskExtraHeight: 0
-            }
           },
           scrollEffectOpts: {
             enableScrollEffect: true,

--- a/entry/src/main/ets/pages/setting/SecuritySheet.ets
+++ b/entry/src/main/ets/pages/setting/SecuritySheet.ets
@@ -9,7 +9,6 @@ import { SubItemDivider } from '../../components/SubItemDivider';
 import { AppWindowInfo } from '../../entryability/EntryAbility';
 import { hilog } from '@kit.PerformanceAnalysisKit';
 import { hdsMaterial, HdsNavigation, HdsNavigationTitleMode, ScrollEffectType } from '@kit.UIDesignKit';
-import { CommonConstants } from '../../utils/CommonConstants';
 import { DlpAntiPeepManager } from '../../utils/DlpAntiPeepManager';
 import { common } from '@kit.AbilityKit';
 
@@ -31,9 +30,6 @@ export struct SecuritySheet {
       HdsNavigation() {
         Column() {
           List({ scroller: this.sheetScroller, space: 10 }) {
-            ListItem()
-              .height(CommonConstants.AVOID_TOP_BASE_HEIGHT)
-
             ListItem() {
               SettingItem({ title: "" }) {
                 SubItemToggle({
@@ -145,6 +141,7 @@ export struct SecuritySheet {
             }
             .padding({ left: 10, right: 10 })
           }
+          .clip(false)
           .width('100%')
           .height('100%')
           .scrollBar(BarState.Off)
@@ -160,6 +157,7 @@ export struct SecuritySheet {
       .bindToScrollable([this.sheetScroller])
       .titleMode(HdsNavigationTitleMode.MODAL)
       .titleBar({
+        enableComponentSafeArea: true,
         style: {
           originalStyle: {
             contentStyle: {
@@ -171,14 +169,6 @@ export struct SecuritySheet {
                 iconColor: $r('sys.color.icon_primary')
               }
             },
-            backgroundStyle: {
-              maskExtraHeight: 0
-            }
-          },
-          scrollEffectStyle: {
-            backgroundStyle: {
-              maskExtraHeight: 0
-            }
           },
           scrollEffectOpts: {
             enableScrollEffect: true,

--- a/entry/src/main/ets/utils/AppFonts.ets
+++ b/entry/src/main/ets/utils/AppFonts.ets
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2023 Huawei Device Co., Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Centralized font family constants.
+ *
+ * OTP/TOTP codes only ever contain ASCII characters (digits 0-9, and for the
+ * Steam variant the ASCII base-26 alphabet), so the generic 'monospace'
+ * family renders identically across all locales. Keeping it as a named
+ * constant gives a single source of truth for all code-display sites.
+ */
+export class AppFonts {
+  static readonly CODE_FONT: string = 'monospace';
+}

--- a/entry/src/main/ets/utils/AppPreference.ets
+++ b/entry/src/main/ets/utils/AppPreference.ets
@@ -325,6 +325,8 @@ export enum ROUTE_NAMES {
   TokenCardConfigPage = 'TokenCardConfigPage',
   /** Token排序页面 */
   TokenSortPage = 'TokenSortPage',
+  /** Token搜索页面 */
+  TokenSearchPage = 'TokenSearchPage',
   /** App首页 */
   IndexPage = 'pages/Index',
 }

--- a/entry/src/main/ets/utils/AppPreference.ets
+++ b/entry/src/main/ets/utils/AppPreference.ets
@@ -160,6 +160,8 @@ export enum PREF_KEYS {
   MASTER_KEY_DEPRECATION_ACKNOWLEDGED = 'app_master_key_deprecation_acknowledged',
   /** ASSET Secret 迁移已完成（持久化标记，避免每次加载重复迁移） */
   ASSET_MIGRATION_DONE = 'app_asset_migration_done',
+  /** 图标包云备份最后同步时间 */
+  ICON_PACK_CLOUD_SYNC_TIME = 'app_icon_pack_cloud_sync_time',
 }
 
 /** 主密码旧偏好键名（已废弃，仅用于兼容性检测与清理） */

--- a/entry/src/main/ets/utils/CloudBackupManager.ets
+++ b/entry/src/main/ets/utils/CloudBackupManager.ets
@@ -430,9 +430,9 @@ export class CloudBackupManager {
       let tokens: TokenConfig[] = [];
       let enabledPacks: string[] = [];
       const payload = JSON.parse(decrypted) as CloudBackupPayload;
-      if (payload.tokens !== undefined && payload.tokens !== null && payload.tokens.length > 0) {
+      if (payload && payload.tokens !== undefined && payload.tokens !== null) {
         tokens = payload.tokens;
-        if (payload.enabledPacks !== undefined && payload.enabledPacks !== null && payload.enabledPacks.length > 0) {
+        if (payload.enabledPacks !== undefined && payload.enabledPacks !== null) {
           enabledPacks = payload.enabledPacks;
         }
       } else {

--- a/entry/src/main/ets/utils/CloudBackupManager.ets
+++ b/entry/src/main/ets/utils/CloudBackupManager.ets
@@ -15,7 +15,7 @@
 
 import { hilog } from '@kit.PerformanceAnalysisKit';
 import { AppPreference, PREF_KEYS } from './AppPreference';
-import { CloudBackupCrypto, CloudBackupCryptoMode, CloudBackupRecord, CloudBackupTokenError } from './CloudBackupCrypto';
+import { CloudBackupCrypto, CloudBackupRecord, CloudBackupTokenError } from './CloudBackupCrypto';
 import { TokenStore } from './TokenStore';
 import { TokenConfig } from './TokenConfig';
 import { fileIo as fs, cloudSync, fileUri } from '@kit.CoreFileKit';
@@ -24,12 +24,24 @@ import { buffer } from '@kit.ArkTS';
 import { DeviceInfoHelper } from './DeviceInfoHelper';
 import { HuaweiAccountManager } from './HuaweiAccountManager';
 import { SyncTimeHelper } from './SyncTimeHelper';
+import { TokenIconPacks } from './TokenUtils';
+import { IconPackCloudBackup, PackMetaEntry } from './IconPackCloudBackup';
 
 const TAG = 'CloudBackupManager';
 const DOMAIN = 0xFF00;
 const MAX_BACKUP_COUNT = 5;
 const BACKUP_FILE_PREFIX = 'otp_backup_';
 const BACKUP_FILE_EXT = '.enc';
+
+/**
+ * 云备份载荷：将 TokenConfig[] 包装为结构化格式，附带图标包启用列表和元数据。
+ * 旧格式（直接序列化为 TokenConfig[]）通过 restoreFromBackupRecord 中的 Array.isArray 检测兼容。
+ */
+class CloudBackupPayload {
+  tokens: TokenConfig[] = [];
+  enabledPacks: string[] = [];
+  packMeta: PackMetaEntry[] = [];
+}
 
 /**
  * 云端备份管理器
@@ -137,8 +149,23 @@ export class CloudBackupManager {
 
     hilog.info(DOMAIN, TAG, `backupToCloud: starting backup, mode=${mode}`);
 
+    // 构造 CloudBackupPayload：包含令牌、图标包启用列表、图标包元数据
     const tokens = await TokenStore.getInstance().getTokens();
-    const plaintext = JSON.stringify(tokens);
+    const enabledPacks = TokenIconPacks.enabled_packs;
+    const payload = new CloudBackupPayload();
+    payload.tokens = tokens;
+    payload.enabledPacks = enabledPacks;
+    const metaList: PackMetaEntry[] = [];
+    for (const p of TokenIconPacks.aegis_icon_packs) {
+      const m = new PackMetaEntry();
+      m.uuid = p.uuid;
+      m.name = p.name;
+      m.version = p.version;
+      m.iconCount = p.icons.length;
+      metaList.push(m);
+    }
+    payload.packMeta = metaList;
+    const plaintext = JSON.stringify(payload);
     const now = Date.now();
 
     hilog.info(DOMAIN, TAG, `backupToCloud: token count=${tokens.length}`);
@@ -177,6 +204,14 @@ export class CloudBackupManager {
     AppPreference.setPreference(PREF_KEYS.CLOUD_SYNC_LAST_TIME, `${now}`);
 
     hilog.info(DOMAIN, TAG, 'backupToCloud: completed successfully');
+
+    // 图标包文件备份：fire-and-forget，不阻塞 token 备份成功返回
+    IconPackCloudBackup.getInstance().backupIconPacks().then((iconResult) => {
+      hilog.info(DOMAIN, TAG, `backupToCloud: icon pack backup result=${iconResult}`);
+    }).catch((err: Error) => {
+      hilog.error(DOMAIN, TAG, `backupToCloud: icon pack backup failed: ${err.message}`);
+    });
+
     return true;
   }
 
@@ -232,6 +267,8 @@ export class CloudBackupManager {
         await this.deleteBackupFile(record.id);
       }
       AppPreference.setPreference(PREF_KEYS.CLOUD_SYNC_LAST_TIME, '0');
+      // 同步清除图标包云端备份（fire-and-forget）
+      IconPackCloudBackup.getInstance().clearCloudBackup();
       hilog.info(DOMAIN, TAG, 'clearCloudStorage: completed');
       return true;
     } catch (e) {
@@ -263,6 +300,8 @@ export class CloudBackupManager {
         await this.deleteBackupFile(record.id);
       }
       AppPreference.setPreference(PREF_KEYS.CLOUD_SYNC_LAST_TIME, '0');
+      // 同步清除图标包云端备份（fire-and-forget）
+      IconPackCloudBackup.getInstance().clearCloudBackup();
       hilog.info(DOMAIN, TAG, `clearDeviceCloudStorage: completed, deleted ${deviceRecords.length}`);
       return true;
     } catch (e) {
@@ -300,6 +339,10 @@ export class CloudBackupManager {
       );
       for (const record of staleRecords) {
         await this.deleteBackupFile(record.id);
+      }
+      if (staleRecords.length > 0) {
+        // 仅在有实际删除时才清除图标包备份（避免不必要的云操作）
+        IconPackCloudBackup.getInstance().clearCloudBackup();
       }
       hilog.info(DOMAIN, TAG, `clearDeviceNameCloudStorage: completed, deleted ${staleRecords.length}`);
       return true;
@@ -383,7 +426,25 @@ export class CloudBackupManager {
       const decrypted = await this.crypto.decrypt(tokenContent, mode, encryptKey);
       hilog.info(DOMAIN, TAG, `restoreFromBackupRecord: decrypted size=${decrypted.length}`);
 
-      const tokens: TokenConfig[] = JSON.parse(decrypted) as TokenConfig[];
+      // 兼容新旧格式：新格式为 CloudBackupPayload（含 tokens 数组），旧格式为 TokenConfig[] 数组
+      let tokens: TokenConfig[] = [];
+      let enabledPacks: string[] = [];
+      const payload = JSON.parse(decrypted) as CloudBackupPayload;
+      if (payload.tokens !== undefined && payload.tokens !== null && payload.tokens.length > 0) {
+        tokens = payload.tokens;
+        if (payload.enabledPacks !== undefined && payload.enabledPacks !== null && payload.enabledPacks.length > 0) {
+          enabledPacks = payload.enabledPacks;
+        }
+      } else {
+        const oldTokens = JSON.parse(decrypted) as TokenConfig[];
+        tokens = oldTokens;
+      }
+
+      if (enabledPacks.length > 0) {
+        AppPreference.saveEnabledPacks(enabledPacks);
+        hilog.info(DOMAIN, TAG, `restoreFromBackupRecord: restored enabledPacks`);
+      }
+
       hilog.info(DOMAIN, TAG, `restoreFromBackupRecord: token count=${tokens.length}`);
 
       for (const token of tokens) {

--- a/entry/src/main/ets/utils/CommonConstants.ets
+++ b/entry/src/main/ets/utils/CommonConstants.ets
@@ -49,6 +49,7 @@ export class CommonConstants {
 
   // Height and width
   static readonly AVOID_TOP_BASE_HEIGHT: number = 56;
+  static readonly AVOID_TOP_WITH_SEARCHBAR_HEIGHT: number = 120;
   static readonly SETTING_OPTION_CARD_HEIGHT: number = 50;
 
   // Swiper duration

--- a/entry/src/main/ets/utils/IconPackCloudBackup.ets
+++ b/entry/src/main/ets/utils/IconPackCloudBackup.ets
@@ -471,7 +471,7 @@ export class IconPackCloudBackup {
     const iconPackDir = this.filesDir + '/icon_packs';
     const userIconDir = this.filesDir + '/user_icons';
 
-    TokenIconPacks.addUserIconPack(userIconDir);
+    await TokenIconPacks.addUserIconPack(userIconDir);
     try {
       const paths = await fs.listFile(iconPackDir);
       for (const path of paths) {

--- a/entry/src/main/ets/utils/IconPackCloudBackup.ets
+++ b/entry/src/main/ets/utils/IconPackCloudBackup.ets
@@ -236,7 +236,10 @@ export class IconPackCloudBackup {
     const tempZipPath = this.cacheDir + '/' + ICON_PACK_BACKUP_ZIP;
 
     try {
-      // 1. 创建 staging 目录
+      // 1. 清理并创建 staging 目录（防止上次中断残留旧文件污染本次备份）
+      try {
+        await this.removeDirRecursive(stagingDir);
+      } catch (_) {}
       try {
         await fs.mkdir(stagingDir);
       } catch (_) {}
@@ -475,8 +478,12 @@ export class IconPackCloudBackup {
     try {
       const paths = await fs.listFile(iconPackDir);
       for (const path of paths) {
+        const fullPath = iconPackDir + '/' + path;
+        if (TokenIconPacks.aegis_icon_packs.some(pack => pack.on_device_path === fullPath)) {
+          continue;
+        }
         try {
-          await TokenIconPacks.addAegisIconPack(iconPackDir + '/' + path);
+          await TokenIconPacks.addAegisIconPack(fullPath);
         } catch (err) {
           hilog.warn(DOMAIN, TAG, `refreshIconPackState: failed to load pack ${path}: ${JSON.stringify(err)}`);
         }
@@ -540,8 +547,9 @@ export class IconPackCloudBackup {
     }
     try {
       const cloudZipPath = this.cloudDir + '/' + ICON_PACK_BACKUP_ZIP;
-      await fs.unlink(cloudZipPath);
-      // 同步删除伴生元数据文件
+      try {
+        await fs.unlink(cloudZipPath);
+      } catch (_) {}
       try {
         await fs.unlink(this.cloudDir + '/' + SYNC_META_FILE);
       } catch (_) {}
@@ -596,13 +604,21 @@ export class IconPackCloudBackup {
   }
 
   private async readFileContent(filePath: string): Promise<string> {
-    const stat = await fs.stat(filePath);
-    const file = fs.openSync(filePath, fs.OpenMode.READ_ONLY);
-    const bufferArray = new ArrayBuffer(stat.size);
-    const readLen = fs.readSync(file.fd, bufferArray);
-    fs.closeSync(file);
-    const uint8Array = new Uint8Array(bufferArray.slice(0, readLen));
-    return buffer.from(uint8Array).toString('utf-8');
+    let file: fs.File | null = null;
+    try {
+      const stat = await fs.stat(filePath);
+      file = await fs.open(filePath, fs.OpenMode.READ_ONLY);
+      const bufferArray = new ArrayBuffer(stat.size);
+      const readLen = await fs.read(file.fd, bufferArray);
+      const uint8Array = new Uint8Array(bufferArray.slice(0, readLen));
+      return buffer.from(uint8Array).toString('utf-8');
+    } finally {
+      if (file) {
+        try {
+          await fs.close(file);
+        } catch (_) {}
+      }
+    }
   }
 
   private async removeDirRecursive(dirPath: string): Promise<void> {

--- a/entry/src/main/ets/utils/IconPackCloudBackup.ets
+++ b/entry/src/main/ets/utils/IconPackCloudBackup.ets
@@ -1,0 +1,654 @@
+import { hilog } from '@kit.PerformanceAnalysisKit';
+import { fileIo as fs, cloudSync, fileUri } from '@kit.CoreFileKit';
+import { common } from '@kit.AbilityKit';
+import { zlib } from '@kit.BasicServicesKit';
+import { buffer } from '@kit.ArkTS';
+import { AppPreference, PREF_KEYS, BUILTIN_DEFAULT_PACK_ID, EVENT_NAMES } from './AppPreference';
+import { TokenIconPacks } from './TokenUtils';
+import { SyncTimeHelper } from './SyncTimeHelper';
+import { HuaweiAccountManager } from './HuaweiAccountManager';
+import { DeviceInfoHelper } from './DeviceInfoHelper';
+
+const TAG = 'IconPackCloudBackup';
+const DOMAIN = 0xFF00;
+const ICON_PACK_BACKUP_ZIP = 'icon_packs_backup.zip';
+const META_JSON_NAME = 'icon_packs_meta.json';
+/**
+ * 云端伴生元数据文件名（放在 cloudDir，与 zip 同级）。
+ * 仅 ~1-2KB，包含时间戳、设备信息、图标包列表。
+ * checkCloudBackupNewer 只读取此文件而不用解压整个 zip，大幅降低冷启动开销。
+ */
+const SYNC_META_FILE = 'icon_packs_sync_meta.json';
+
+/**
+ * 图标包云备份同步状态机
+ *
+ * 状态转换图：
+ *   IDLE ──→ BACKING_UP ──→ IDLE   (备份图标包到云端)
+ *   IDLE ──→ RESTORING   ──→ IDLE   (从云端恢复图标包)
+ *   IDLE ──→ CLEARING    ──→ IDLE   (清除云端图标包备份)
+ *   IDLE ──→ CHECKING    ──→ IDLE   (检查云端备份是否较新)
+ *
+ * 规则：只有 IDLE 状态才能转换到其他状态，任何操作结束后（无论成功/失败）均回到 IDLE。
+ * 这确保了备份、恢复、清理、检查四类操作互斥，不会同时操作同一组文件。
+ *
+ * 生命周期：纯内存态（实例变量），不持久化。
+ * - 应用重启后 singleton 重建，状态自动重置为 IDLE，不会出现永久锁死。
+ * - 进程被系统回收同理。
+ */
+export enum IconPackSyncState {
+  IDLE = 0,
+  BACKING_UP = 1,
+  RESTORING = 2,
+  CLEARING = 3,
+  CHECKING = 4,
+}
+
+export class IconPackRestoreResult {
+  restoredCount: number = 0;
+  restoredFiles: number = 0;
+}
+
+export class IconPackBackupStatus {
+  exists: boolean = false;
+  packCount: number = 0;
+  size: number = 0;
+  lastTime: string = '';
+  sourceDeviceName: string = '';
+  sourceDeviceId: string = '';
+  packs: PackMetaEntry[] = [];
+}
+
+export class PackMetaEntry {
+  uuid: string = '';
+  name: string = '';
+  version: number = 0;
+  iconCount: number = 0;
+}
+
+/**
+ * 备份 zip 内的元数据记录，包含时间戳、启用的图标包列表、已删除的图标包列表等。
+ */
+class IconPackMetaRecord {
+  version: number = 0;
+  timestamp: number = 0;
+  enabledPacks: string[] = [];
+  deletedPacks: string[] = [];
+  packs: PackMetaEntry[] = [];
+}
+
+/**
+ * 云端伴生元数据文件的结构（SYNC_META_FILE）。
+ * 与 zip 同级存放，供 checkCloudBackupNewer 直接读取，避免解压整个 zip。
+ * 含设备信息便于 UI 展示"此备份来自 xxx 设备"。
+ */
+class SyncMetaRecord {
+  version: number = 0;
+  timestamp: number = 0;
+  deviceId: string = '';
+  deviceName: string = '';
+  enabledPacks: string[] = [];
+  deletedPacks: string[] = [];
+  packs: PackMetaEntry[] = [];
+}
+
+/**
+ * 图标包云备份/恢复管理器（单例）
+ *
+ * 职责：
+ * 1. 将 icon_packs/ 和 user_icons/ 目录打包为 zip，通过 FileSync 上传到华为云
+ * 2. 从云端下载 zip，解压并合并到本地 filesDir
+ * 3. 管理 enabledPacks 列表的云端同步（随 token 备份一起序列化）
+ *
+ * 线程安全：ArkTS 单线程事件循环，通过 IconPackSyncState 状态机保证操作互斥，
+ * 不需要真正的锁。所有公开异步方法在入口处 tryTransition，在 finally 中回到 IDLE。
+ *
+ * 状态机生命周期：纯内存态，不持久化。应用重启后 singleton 重建，自动恢复 IDLE。
+ */
+export class IconPackCloudBackup {
+  private static instance: IconPackCloudBackup | null = null;
+  private context: common.UIAbilityContext | undefined = undefined;
+  private cloudDir: string = '';
+  private filesDir: string = '';
+  private cacheDir: string = '';
+  private fileSync: cloudSync.FileSync | null = null;
+  /** 状态机当前状态，纯内存态，重启自动重置 */
+  private syncState: IconPackSyncState = IconPackSyncState.IDLE;
+
+  private constructor() {
+  }
+
+  static getInstance(): IconPackCloudBackup {
+    if (!IconPackCloudBackup.instance) {
+      IconPackCloudBackup.instance = new IconPackCloudBackup();
+    }
+    return IconPackCloudBackup.instance;
+  }
+
+  async init(): Promise<void> {
+    if (this.context) {
+      return;
+    }
+    this.context = AppStorage.get<common.UIAbilityContext>('appContext') as common.UIAbilityContext;
+    if (!this.context) {
+      hilog.error(DOMAIN, TAG, 'init: failed to get appContext');
+      return;
+    }
+    this.filesDir = this.context.filesDir;
+    this.cloudDir = this.context.cloudFileDir;
+    this.cacheDir = this.context.cacheDir;
+  }
+
+  /**
+   * 冷启动自动恢复入口（Index.ets deferredInit 调用）
+   *
+   * 流程：IDLE→RESTORING → 前置条件检查 → 检查云端时间戳 → 恢复 → 合并 enabledPacks → 发事件 → IDLE
+   * 直接调用 doCheckCloudBackupNewer/doRestoreIconPacks（私有方法，不经过状态检查），
+   * 因为整个 check+restore 已在 RESTORING 状态保护下作为原子操作执行。
+   */
+  async checkAndAutoRestore(): Promise<boolean> {
+    await this.init();
+    if (!this.context || !this.cloudDir) return false;
+
+    if (!this.tryTransition(IconPackSyncState.RESTORING)) {
+      hilog.warn(DOMAIN, TAG, `checkAndAutoRestore: state=${this.syncState}, skip`);
+      return false;
+    }
+    try {
+      const enabled = AppPreference.getPreference(PREF_KEYS.APPEARANCE_HUAWEI_CLOUD_SYNC_ENABLE) as boolean;
+      if (!enabled) return false;
+      if (!HuaweiAccountManager.getInstance().userLogin) return false;
+
+      if (!await this.doCheckCloudBackupNewer()) return false;
+
+      const result = await this.doRestoreIconPacks();
+      if (result.restoredCount > 0 || result.restoredFiles > 0) {
+        this.context.eventHub?.emit(EVENT_NAMES.ICON_PACK_CHANGED);
+      }
+      return result.restoredCount > 0 || result.restoredFiles > 0;
+    } finally {
+      this.syncState = IconPackSyncState.IDLE;
+    }
+  }
+
+  /**
+   * 备份图标包到云端（由 CloudBackupManager.backupToCloud 在 token 备份成功后 fire-and-forget 调用）
+   *
+   * 流程：IDLE→BACKING_UP → 检查本地是否有图标包 → 拷贝到 staging → 压缩 zip →
+   *       复制到 cloudDir → FileSync.start() → IDLE
+   */
+  async backupIconPacks(): Promise<boolean> {
+    await this.init();
+    if (!this.context || !this.cloudDir) {
+      return false;
+    }
+    if (!this.tryTransition(IconPackSyncState.BACKING_UP)) {
+      hilog.warn(DOMAIN, TAG, `backupIconPacks: state=${this.syncState}, skip`);
+      return false;
+    }
+    try {
+      return await this.doBackupIconPacks();
+    } finally {
+      this.syncState = IconPackSyncState.IDLE;
+    }
+  }
+
+  /** 实际备份逻辑：staging 目录构建 → zip 压缩 → 复制到 cloudDir → 触发同步 */
+  private async doBackupIconPacks(): Promise<boolean> {
+    const iconPackDir = this.filesDir + '/icon_packs';
+    const userIconDir = this.filesDir + '/user_icons';
+    let hasContent = false;
+
+    try {
+      const packFiles = fs.listFileSync(iconPackDir);
+      if (packFiles.length > 0) hasContent = true;
+    } catch (_) {}
+
+    try {
+      const userFiles = fs.listFileSync(userIconDir);
+      if (userFiles.length > 0) hasContent = true;
+    } catch (_) {}
+
+    if (!hasContent) {
+      hilog.info(DOMAIN, TAG, 'backupIconPacks: no icon packs to backup, skip');
+      return true;
+    }
+
+    const now = Date.now();
+    const packEntries: PackMetaEntry[] = [];
+    for (const p of TokenIconPacks.aegis_icon_packs) {
+      const entry = new PackMetaEntry();
+      entry.uuid = p.uuid;
+      entry.name = p.name;
+      entry.version = p.version;
+      entry.iconCount = p.icons.length;
+      packEntries.push(entry);
+    }
+    const meta = new IconPackMetaRecord();
+    meta.version = 1;
+    meta.timestamp = now;
+    meta.enabledPacks = TokenIconPacks.enabled_packs;
+    meta.deletedPacks = [];
+    meta.packs = packEntries;
+
+    const stagingDir = this.cacheDir + '/icon_pack_staging';
+    const metaPath = stagingDir + '/' + META_JSON_NAME;
+    const tempZipPath = this.cacheDir + '/' + ICON_PACK_BACKUP_ZIP;
+
+    try {
+      // 1. 创建 staging 目录
+      try {
+        await fs.mkdir(stagingDir);
+      } catch (_) {}
+
+      // 2. 写入元数据文件
+      const metaFile = fs.openSync(metaPath, fs.OpenMode.WRITE_ONLY | fs.OpenMode.CREATE | fs.OpenMode.TRUNC);
+      fs.writeSync(metaFile.fd, JSON.stringify(meta));
+      fs.closeSync(metaFile);
+
+      // 3. 递归拷贝 icon_packs 和 user_icons 到 staging（必须用 copyDirRecursive，fs.copyFile 不支持目录）
+      try {
+        const destIconDir = stagingDir + '/icon_packs';
+        await fs.mkdir(destIconDir);
+        this.copyDirRecursive(iconPackDir, destIconDir);
+      } catch (_) {}
+      try {
+        const destUserDir = stagingDir + '/user_icons';
+        await fs.mkdir(destUserDir);
+        this.copyDirRecursive(userIconDir, destUserDir);
+      } catch (_) {}
+
+      // 4. 压缩 staging 目录为 zip
+      const options: zlib.Options = {
+        level: zlib.CompressLevel.COMPRESS_LEVEL_DEFAULT_COMPRESSION,
+      };
+      await zlib.compressFile(stagingDir, tempZipPath, options);
+
+      // 5. 将 zip 复制到 cloudDir
+      const cloudZipPath = this.cloudDir + '/' + ICON_PACK_BACKUP_ZIP;
+      fs.copyFileSync(tempZipPath, cloudZipPath);
+
+      // 6. 写入伴生元数据文件（~1-2KB，含设备信息、时间戳、图标包列表）
+      const syncMeta = new SyncMetaRecord();
+      syncMeta.version = 1;
+      syncMeta.timestamp = now;
+      syncMeta.deviceId = DeviceInfoHelper.getInstance().getDeviceId();
+      syncMeta.deviceName = DeviceInfoHelper.getInstance().getDeviceName();
+      syncMeta.enabledPacks = TokenIconPacks.enabled_packs;
+      syncMeta.deletedPacks = [];
+      syncMeta.packs = packEntries;
+      const syncMetaPath = this.cloudDir + '/' + SYNC_META_FILE;
+      const syncMetaFile = fs.openSync(syncMetaPath, fs.OpenMode.WRITE_ONLY | fs.OpenMode.CREATE | fs.OpenMode.TRUNC);
+      fs.writeSync(syncMetaFile.fd, JSON.stringify(syncMeta));
+      fs.closeSync(syncMetaFile);
+
+      // 7. 触发云端同步（zip + 伴生文件一起上传）
+      await this.syncToCloud();
+
+      AppPreference.setPreference(PREF_KEYS.ICON_PACK_CLOUD_SYNC_TIME, `${now}`);
+      hilog.info(DOMAIN, TAG, `backupIconPacks: completed, timestamp=${now}`);
+      return true;
+    } catch (e) {
+      hilog.error(DOMAIN, TAG, `backupIconPacks: error=${JSON.stringify(e)}`);
+      return false;
+    } finally {
+      this.removeDirRecursive(stagingDir);
+      try {
+        await fs.unlink(tempZipPath);
+      } catch (_) {}
+    }
+  }
+
+  /**
+   * 检查云端备份是否比本地更新（公开入口，外部可独立调用）
+   * 内部先做 5 分钟去抖，再读取伴生元数据文件比较时间戳（不解压 zip）。
+   */
+  async checkCloudBackupNewer(): Promise<boolean> {
+    await this.init();
+    if (!this.context || !this.cloudDir) {
+      return false;
+    }
+    if (!this.tryTransition(IconPackSyncState.CHECKING)) {
+      hilog.warn(DOMAIN, TAG, `checkCloudBackupNewer: state=${this.syncState}, skip`);
+      return false;
+    }
+    try {
+      return await this.doCheckCloudBackupNewer();
+    } finally {
+      this.syncState = IconPackSyncState.IDLE;
+    }
+  }
+
+  /** 读取云端伴生元数据文件比较 timestamp，无需下载/解压 zip */
+  private async doCheckCloudBackupNewer(): Promise<boolean> {
+    const lastRestoreStr = AppPreference.getPreference(PREF_KEYS.ICON_PACK_CLOUD_SYNC_TIME) as string;
+    const lastRestoreTs = SyncTimeHelper.parseStoredTimestamp(lastRestoreStr);
+    if (lastRestoreTs > 0 && SyncTimeHelper.isWithinMinutes(lastRestoreTs, 5)) {
+      hilog.info(DOMAIN, TAG, 'checkCloudBackupNewer: restored within 5 min, skip');
+      return false;
+    }
+
+    const syncMetaPath = this.cloudDir + '/' + SYNC_META_FILE;
+    try {
+      const stat = await fs.stat(syncMetaPath);
+      if (stat.location === 2) {
+        await this.cacheFile(syncMetaPath);
+      }
+
+      const content = await this.readFileContent(syncMetaPath);
+      const meta = JSON.parse(content) as SyncMetaRecord;
+      const cloudTs = meta.timestamp || 0;
+      hilog.info(DOMAIN, TAG, `checkCloudBackupNewer: cloudTs=${cloudTs}, localTs=${lastRestoreTs}, device=${meta.deviceName}`);
+      return cloudTs > lastRestoreTs;
+    } catch (e) {
+      hilog.info(DOMAIN, TAG, `checkCloudBackupNewer: no sync meta or error=${JSON.stringify(e)}`);
+      return false;
+    }
+  }
+
+  /**
+   * 从云端恢复图标包（公开入口，checkAndAutoRestore 内部直接调用 doRestoreIconPacks）
+   *
+   * 流程：IDLE→RESTORING → 下载解压 → 拷贝到 filesDir → 处理 deletedPacks →
+   *       刷新内存状态 → 合并 enabledPacks → IDLE
+   */
+  async restoreIconPacks(): Promise<IconPackRestoreResult> {
+    await this.init();
+    if (!this.context || !this.cloudDir) {
+      return new IconPackRestoreResult();
+    }
+    if (!this.tryTransition(IconPackSyncState.RESTORING)) {
+      hilog.warn(DOMAIN, TAG, `restoreIconPacks: state=${this.syncState}, skip`);
+      return new IconPackRestoreResult();
+    }
+    try {
+      return await this.doRestoreIconPacks();
+    } finally {
+      this.syncState = IconPackSyncState.IDLE;
+    }
+  }
+
+  /** 实际恢复逻辑：解压 → 拷贝文件 → 处理已删除包 → 刷新内存 → 合并启用列表 */
+  private async doRestoreIconPacks(): Promise<IconPackRestoreResult> {
+    const cloudZipPath = this.cloudDir + '/' + ICON_PACK_BACKUP_ZIP;
+    try {
+      // 若文件仍在云端（location=2），先缓存到本地
+      const stat = await fs.stat(cloudZipPath);
+      if (stat.location === 2) {
+        await this.cacheFile(cloudZipPath);
+      }
+
+      // 解压到临时目录（cacheDir，不直接写 filesDir）
+      const tempDir = this.cacheDir + '/icon_pack_restore';
+      try {
+        await fs.mkdir(tempDir);
+      } catch (_) {}
+
+      await zlib.decompressFile(cloudZipPath, tempDir);
+
+      // 确保目标目录存在
+      const iconPackDir = this.filesDir + '/icon_packs';
+      const userIconDir = this.filesDir + '/user_icons';
+      try {
+        fs.mkdirSync(iconPackDir);
+      } catch (_) {}
+      try {
+        fs.mkdirSync(userIconDir);
+      } catch (_) {}
+
+      // 选择性拷贝：只还原 icon_packs 和 user_icons 子目录
+      const tempIconPacks = tempDir + '/icon_packs';
+      const tempUserIcons = tempDir + '/user_icons';
+      try {
+        this.copyDirRecursive(tempIconPacks, iconPackDir);
+      } catch (_) {}
+      try {
+        this.copyDirRecursive(tempUserIcons, userIconDir);
+      } catch (_) {}
+
+      // 读取元数据
+      let meta: IconPackMetaRecord | null = null;
+      try {
+        const metaContent = await this.readFileContent(tempDir + '/' + META_JSON_NAME);
+        meta = JSON.parse(metaContent) as IconPackMetaRecord;
+      } catch (_) {}
+
+      // 清理临时目录
+      this.removeDirRecursive(tempDir);
+
+      if (meta) {
+        // 处理云端标记为已删除的图标包
+        if (meta.deletedPacks && meta.deletedPacks.length > 0) {
+          for (const deletedUuid of meta.deletedPacks) {
+            const pack = TokenIconPacks.aegis_icon_packs.find(p => p.uuid === deletedUuid);
+            if (pack) {
+              try {
+                await TokenIconPacks.removeAegisIconPack(pack);
+              } catch (e) {
+                hilog.warn(DOMAIN, TAG, `restoreIconPacks: failed to delete pack ${deletedUuid}: ${JSON.stringify(e)}`);
+              }
+            }
+          }
+        }
+
+        // 在 merge 前重新从磁盘加载图标包，使 TokenIconPacks 内存状态包含新拷贝的文件
+        await this.refreshIconPackState();
+
+        // 合并策略：以云端 enabledPacks 为基础，追加本地独有的包（不丢失本地新增包）
+        const basePacks = meta.enabledPacks && meta.enabledPacks.length > 0
+          ? meta.enabledPacks
+          : [BUILTIN_DEFAULT_PACK_ID];
+        let merged = [...basePacks];
+        const localPacks = TokenIconPacks.aegis_icon_packs.map(p => p.uuid);
+        for (const localUuid of localPacks) {
+          if (!merged.includes(localUuid)) {
+            merged.push(localUuid);
+          }
+        }
+
+        TokenIconPacks.enabled_packs = merged;
+        AppPreference.saveEnabledPacks(merged);
+        AppPreference.setPreference(PREF_KEYS.ICON_PACK_CLOUD_SYNC_TIME, `${meta.timestamp}`);
+
+        hilog.info(DOMAIN, TAG, `restoreIconPacks: merged enabledPacks=${JSON.stringify(merged)}`);
+      }
+
+      const result = new IconPackRestoreResult();
+      result.restoredCount = meta?.packs?.length ?? 0;
+      result.restoredFiles = 1;
+      return result;
+    } catch (e) {
+      hilog.error(DOMAIN, TAG, `restoreIconPacks: error=${JSON.stringify(e)}`);
+      return new IconPackRestoreResult();
+    }
+  }
+
+  /**
+   * 从磁盘重新加载图标包到 TokenIconPacks 内存（在 merge enabledPacks 前调用）
+   * 包含：user_icons 目录 + icon_packs 下所有子目录 + enabled_packs 偏好
+   */
+  private async refreshIconPackState(): Promise<void> {
+    const iconPackDir = this.filesDir + '/icon_packs';
+    const userIconDir = this.filesDir + '/user_icons';
+
+    TokenIconPacks.addUserIconPack(userIconDir);
+    try {
+      const paths = await fs.listFile(iconPackDir);
+      for (const path of paths) {
+        try {
+          await TokenIconPacks.addAegisIconPack(iconPackDir + '/' + path);
+        } catch (err) {
+          hilog.warn(DOMAIN, TAG, `refreshIconPackState: failed to load pack ${path}: ${JSON.stringify(err)}`);
+        }
+      }
+    } catch (err) {
+      hilog.warn(DOMAIN, TAG, `refreshIconPackState: failed to list ${iconPackDir}: ${JSON.stringify(err)}`);
+    }
+    TokenIconPacks.enabled_packs = AppPreference.loadEnabledPacks();
+  }
+
+  /** 查询云端图标包备份状态（是否存在、包数量、大小、来源设备等），供 UI 展示 */
+  async getCloudBackupStatus(): Promise<IconPackBackupStatus> {
+    await this.init();
+    const result = new IconPackBackupStatus();
+
+    const lastTimeStr = AppPreference.getPreference(PREF_KEYS.ICON_PACK_CLOUD_SYNC_TIME) as string;
+    const lastTs = SyncTimeHelper.parseStoredTimestamp(lastTimeStr);
+    result.lastTime = SyncTimeHelper.formatTimestamp(lastTs);
+
+    if (!this.context || !this.cloudDir) {
+      return result;
+    }
+
+    const cloudZipPath = this.cloudDir + '/' + ICON_PACK_BACKUP_ZIP;
+    try {
+      const stat = await fs.stat(cloudZipPath);
+      result.exists = true;
+      result.size = stat.size;
+    } catch (_) {}
+
+    // 从伴生元数据文件读取详细信息（包列表、来源设备等）
+    const syncMetaPath = this.cloudDir + '/' + SYNC_META_FILE;
+    try {
+      const smStat = await fs.stat(syncMetaPath);
+      if (smStat.location === 2) {
+        await this.cacheFile(syncMetaPath);
+      }
+      const content = await this.readFileContent(syncMetaPath);
+      const meta = JSON.parse(content) as SyncMetaRecord;
+      result.packCount = meta.packs?.length ?? 0;
+      result.sourceDeviceId = meta.deviceId ?? '';
+      result.sourceDeviceName = meta.deviceName ?? '';
+      result.packs = meta.packs ?? [];
+    } catch (_) {
+      // 伴生文件不存在（旧版本备份），回退到本地内存
+      result.packCount = TokenIconPacks.aegis_icon_packs.length;
+    }
+
+    return result;
+  }
+
+  /** 删除云端图标包备份 zip（由 CloudBackupManager 的三个 clear 方法调用） */
+  async clearCloudBackup(): Promise<boolean> {
+    await this.init();
+    if (!this.context || !this.cloudDir) {
+      return false;
+    }
+    if (!this.tryTransition(IconPackSyncState.CLEARING)) {
+      hilog.warn(DOMAIN, TAG, `clearCloudBackup: state=${this.syncState}, skip`);
+      return false;
+    }
+    try {
+      const cloudZipPath = this.cloudDir + '/' + ICON_PACK_BACKUP_ZIP;
+      await fs.unlink(cloudZipPath);
+      // 同步删除伴生元数据文件
+      try {
+        await fs.unlink(this.cloudDir + '/' + SYNC_META_FILE);
+      } catch (_) {}
+      await this.syncToCloud();
+      hilog.info(DOMAIN, TAG, 'clearCloudBackup: completed');
+      return true;
+    } catch (e) {
+      hilog.error(DOMAIN, TAG, `clearCloudBackup: error=${JSON.stringify(e)}`);
+      return false;
+    } finally {
+      this.syncState = IconPackSyncState.IDLE;
+    }
+  }
+
+  /** 状态机原子转换：仅 IDLE→target 允许，其他状态拒绝（返回 false） */
+  private tryTransition(target: IconPackSyncState): boolean {
+    if (this.syncState !== IconPackSyncState.IDLE) {
+      return false;
+    }
+    this.syncState = target;
+    return true;
+  }
+
+  /** 暴露当前状态机状态，供 UI 层查询同步进度 */
+  getState(): IconPackSyncState {
+    return this.syncState;
+  }
+
+  /** 触发 FileSync.start() 将 cloudDir 变更同步到云端（复用实例避免重复创建） */
+  private async syncToCloud(): Promise<void> {
+    if (!this.fileSync) {
+      this.fileSync = new cloudSync.FileSync();
+    }
+    try {
+      await this.fileSync.start();
+      hilog.info(DOMAIN, TAG, 'syncToCloud: started');
+    } catch (e) {
+      hilog.error(DOMAIN, TAG, `syncToCloud: error=${JSON.stringify(e)}`);
+    }
+  }
+
+  /** 将云端文件（location=2）缓存到本地，以便读取内容 */
+  private async cacheFile(filePath: string): Promise<void> {
+    const uri = fileUri.getUriFromPath(filePath);
+    const cache = new cloudSync.CloudFileCache();
+    try {
+      await cache.start(uri);
+      hilog.info(DOMAIN, TAG, `cacheFile: cached ${filePath}`);
+    } catch (e) {
+      hilog.error(DOMAIN, TAG, `cacheFile: error=${JSON.stringify(e)}`);
+    }
+  }
+
+  private async readFileContent(filePath: string): Promise<string> {
+    const stat = await fs.stat(filePath);
+    const file = fs.openSync(filePath, fs.OpenMode.READ_ONLY);
+    const bufferArray = new ArrayBuffer(stat.size);
+    const readLen = fs.readSync(file.fd, bufferArray);
+    fs.closeSync(file);
+    const uint8Array = new Uint8Array(bufferArray.slice(0, readLen));
+    return buffer.from(uint8Array).toString('utf-8');
+  }
+
+  private removeDirRecursive(dirPath: string): void {
+    try {
+      const files = fs.listFileSync(dirPath);
+      for (const file of files) {
+        const fullPath = dirPath + '/' + file;
+        try {
+          const stat = fs.statSync(fullPath);
+          if (stat.isDirectory()) {
+            this.removeDirRecursive(fullPath);
+          } else {
+            fs.unlinkSync(fullPath);
+          }
+        } catch (e) {
+          hilog.warn(DOMAIN, TAG, `removeDirRecursive: failed to remove ${fullPath}: ${JSON.stringify(e)}`);
+        }
+      }
+      fs.rmdirSync(dirPath);
+    } catch (e) {
+      hilog.warn(DOMAIN, TAG, `removeDirRecursive: failed to process ${dirPath}: ${JSON.stringify(e)}`);
+    }
+  }
+
+  private copyDirRecursive(srcDir: string, destDir: string): void {
+    try {
+      const files = fs.listFileSync(srcDir);
+      for (const file of files) {
+        const srcPath = srcDir + '/' + file;
+        const destPath = destDir + '/' + file;
+        try {
+          const stat = fs.statSync(srcPath);
+          if (stat.isDirectory()) {
+            try {
+              fs.mkdirSync(destPath);
+            } catch (_) {}
+            this.copyDirRecursive(srcPath, destPath);
+          } else {
+            fs.copyFileSync(srcPath, destPath);
+          }
+        } catch (e) {
+          hilog.warn(DOMAIN, TAG, `copyDirRecursive: failed to copy ${srcPath}: ${JSON.stringify(e)}`);
+        }
+      }
+    } catch (e) {
+      hilog.warn(DOMAIN, TAG, `copyDirRecursive: failed to read ${srcDir}: ${JSON.stringify(e)}`);
+    }
+  }
+}

--- a/entry/src/main/ets/utils/IconPackCloudBackup.ets
+++ b/entry/src/main/ets/utils/IconPackCloudBackup.ets
@@ -250,12 +250,12 @@ export class IconPackCloudBackup {
       try {
         const destIconDir = stagingDir + '/icon_packs';
         await fs.mkdir(destIconDir);
-        this.copyDirRecursive(iconPackDir, destIconDir);
+        await this.copyDirRecursive(iconPackDir, destIconDir);
       } catch (_) {}
       try {
         const destUserDir = stagingDir + '/user_icons';
         await fs.mkdir(destUserDir);
-        this.copyDirRecursive(userIconDir, destUserDir);
+        await this.copyDirRecursive(userIconDir, destUserDir);
       } catch (_) {}
 
       // 4. 压缩 staging 目录为 zip
@@ -266,7 +266,7 @@ export class IconPackCloudBackup {
 
       // 5. 将 zip 复制到 cloudDir
       const cloudZipPath = this.cloudDir + '/' + ICON_PACK_BACKUP_ZIP;
-      fs.copyFileSync(tempZipPath, cloudZipPath);
+      await fs.copyFile(tempZipPath, cloudZipPath);
 
       // 6. 写入伴生元数据文件（~1-2KB，含设备信息、时间戳、图标包列表）
       const syncMeta = new SyncMetaRecord();
@@ -292,7 +292,7 @@ export class IconPackCloudBackup {
       hilog.error(DOMAIN, TAG, `backupIconPacks: error=${JSON.stringify(e)}`);
       return false;
     } finally {
-      this.removeDirRecursive(stagingDir);
+      await this.removeDirRecursive(stagingDir);
       try {
         await fs.unlink(tempZipPath);
       } catch (_) {}
@@ -400,10 +400,10 @@ export class IconPackCloudBackup {
       const tempIconPacks = tempDir + '/icon_packs';
       const tempUserIcons = tempDir + '/user_icons';
       try {
-        this.copyDirRecursive(tempIconPacks, iconPackDir);
+        await this.copyDirRecursive(tempIconPacks, iconPackDir);
       } catch (_) {}
       try {
-        this.copyDirRecursive(tempUserIcons, userIconDir);
+        await this.copyDirRecursive(tempUserIcons, userIconDir);
       } catch (_) {}
 
       // 读取元数据
@@ -414,7 +414,7 @@ export class IconPackCloudBackup {
       } catch (_) {}
 
       // 清理临时目录
-      this.removeDirRecursive(tempDir);
+      await this.removeDirRecursive(tempDir);
 
       if (meta) {
         // 处理云端标记为已删除的图标包
@@ -605,43 +605,43 @@ export class IconPackCloudBackup {
     return buffer.from(uint8Array).toString('utf-8');
   }
 
-  private removeDirRecursive(dirPath: string): void {
+  private async removeDirRecursive(dirPath: string): Promise<void> {
     try {
-      const files = fs.listFileSync(dirPath);
+      const files = await fs.listFile(dirPath);
       for (const file of files) {
         const fullPath = dirPath + '/' + file;
         try {
-          const stat = fs.statSync(fullPath);
+          const stat = await fs.stat(fullPath);
           if (stat.isDirectory()) {
-            this.removeDirRecursive(fullPath);
+            await this.removeDirRecursive(fullPath);
           } else {
-            fs.unlinkSync(fullPath);
+            await fs.unlink(fullPath);
           }
         } catch (e) {
           hilog.warn(DOMAIN, TAG, `removeDirRecursive: failed to remove ${fullPath}: ${JSON.stringify(e)}`);
         }
       }
-      fs.rmdirSync(dirPath);
+      await fs.rmdir(dirPath);
     } catch (e) {
       hilog.warn(DOMAIN, TAG, `removeDirRecursive: failed to process ${dirPath}: ${JSON.stringify(e)}`);
     }
   }
 
-  private copyDirRecursive(srcDir: string, destDir: string): void {
+  private async copyDirRecursive(srcDir: string, destDir: string): Promise<void> {
     try {
-      const files = fs.listFileSync(srcDir);
+      const files = await fs.listFile(srcDir);
       for (const file of files) {
         const srcPath = srcDir + '/' + file;
         const destPath = destDir + '/' + file;
         try {
-          const stat = fs.statSync(srcPath);
+          const stat = await fs.stat(srcPath);
           if (stat.isDirectory()) {
             try {
-              fs.mkdirSync(destPath);
+              await fs.mkdir(destPath);
             } catch (_) {}
-            this.copyDirRecursive(srcPath, destPath);
+            await this.copyDirRecursive(srcPath, destPath);
           } else {
-            fs.copyFileSync(srcPath, destPath);
+            await fs.copyFile(srcPath, destPath);
           }
         } catch (e) {
           hilog.warn(DOMAIN, TAG, `copyDirRecursive: failed to copy ${srcPath}: ${JSON.stringify(e)}`);

--- a/entry/src/main/resources/base/element/string.json
+++ b/entry/src/main/resources/base/element/string.json
@@ -222,7 +222,7 @@
     },
     {
       "name": "data_rdb_sync_des",
-      "value": "The distributed application data sync allows the data of an application to be synced with other devices that are connected to form a Virtual Device."
+      "value": "Data will be synced to other devices logged into your Huawei account in the same network. Only token data is synced; icon packs and preferences are not included."
     },
     {
       "name": "data_rdb_cloud_sync",
@@ -230,7 +230,7 @@
     },
     {
       "name": "data_rdb_cloud_sync_des",
-      "value": "Backup app data to Huawei Cloud. Data will be backed up to Huawei Cloud Drive."
+      "value": "Backup token and icon pack data to Huawei Cloud. Data will be stored securely in Huawei Cloud."
     },
     {
       "name": "data_rdb_sync_details",
@@ -398,7 +398,7 @@
     },
     {
       "name": "data_kv_sync_manual_des",
-      "value": "Sync all tokens to other devices"
+      "value": "Sync all tokens to other devices (icon packs excluded)"
     },
     {
       "name": "cloud_backup_manual",
@@ -1263,6 +1263,58 @@
     {
       "name": "importer_uri_desc",
       "value": "粘贴 otpauth:// 链接导入令牌"
+    },
+    {
+      "name": "icon_pack_cloud_backup_hint",
+      "value": "Icon pack settings are automatically synced to all your devices via Huawei Cloud Backup. See \"Backup & Migration > Huawei Cloud Backup\" for details."
+    },
+    {
+      "name": "cloud_sync_icon_pack_title",
+      "value": "Icon Pack Backup"
+    },
+    {
+      "name": "cloud_sync_icon_pack_status",
+      "value": "Backup Status"
+    },
+    {
+      "name": "cloud_sync_icon_pack_status_done_suffix",
+      "value": "packs backed up,"
+    },
+    {
+      "name": "cloud_sync_icon_pack_status_none",
+      "value": "Not backed up"
+    },
+    {
+      "name": "cloud_sync_icon_pack_status_empty",
+      "value": "No icon packs"
+    },
+    {
+      "name": "cloud_sync_icon_pack_last_time",
+      "value": "Last Backup"
+    },
+    {
+      "name": "cloud_sync_icon_pack_source_device",
+      "value": "Source Device"
+    },
+    {
+      "name": "cloud_sync_icon_pack_hint",
+      "value": "Icon pack files and preferences are backed up to Huawei Cloud along with your tokens and automatically restored to all devices."
+    },
+    {
+      "name": "cloud_sync_icon_pack_state_backing_up",
+      "value": "Backing up..."
+    },
+    {
+      "name": "cloud_sync_icon_pack_state_restoring",
+      "value": "Restoring..."
+    },
+    {
+      "name": "cloud_sync_icon_pack_state_clearing",
+      "value": "Clearing..."
+    },
+    {
+      "name": "cloud_sync_icon_pack_state_checking",
+      "value": "Checking..."
     }
   ]
 }

--- a/entry/src/main/resources/en_US/element/string.json
+++ b/entry/src/main/resources/en_US/element/string.json
@@ -226,7 +226,7 @@
     },
     {
       "name": "data_rdb_sync_des",
-      "value": "Data will be synced to other devices logged into your Huawei account in the same network."
+      "value": "Data will be synced to other devices logged into your Huawei account in the same network. Only token data is synced; icon packs and preferences are not included."
     },
     {
       "name": "data_rdb_cloud_sync",
@@ -234,7 +234,7 @@
     },
     {
       "name": "data_rdb_cloud_sync_des",
-      "value": "Backup app data to Huawei Cloud. Data will be backed up to Huawei Cloud Drive."
+      "value": "Backup token and icon pack data to Huawei Cloud. Data will be stored securely in Huawei Cloud."
     },
     {
       "name": "data_rdb_sync_details",
@@ -402,7 +402,7 @@
     },
     {
       "name": "data_kv_sync_manual_des",
-      "value": "Sync all tokens to other devices"
+      "value": "Sync all tokens to other devices (icon packs excluded)"
     },
     {
       "name": "cloud_backup_manual",
@@ -1263,6 +1263,58 @@
     {
       "name": "importer_uri_desc",
       "value": "Paste otpauth:// URIs to import"
+    },
+    {
+      "name": "icon_pack_cloud_backup_hint",
+      "value": "Icon pack settings are automatically synced to all your devices via Huawei Cloud Backup. See \"Backup & Migration > Huawei Cloud Backup\" for details."
+    },
+    {
+      "name": "cloud_sync_icon_pack_title",
+      "value": "Icon Pack Backup"
+    },
+    {
+      "name": "cloud_sync_icon_pack_status",
+      "value": "Backup Status"
+    },
+    {
+      "name": "cloud_sync_icon_pack_status_done_suffix",
+      "value": "packs backed up,"
+    },
+    {
+      "name": "cloud_sync_icon_pack_status_none",
+      "value": "Not backed up"
+    },
+    {
+      "name": "cloud_sync_icon_pack_status_empty",
+      "value": "No icon packs"
+    },
+    {
+      "name": "cloud_sync_icon_pack_last_time",
+      "value": "Last Backup"
+    },
+    {
+      "name": "cloud_sync_icon_pack_source_device",
+      "value": "Source Device"
+    },
+    {
+      "name": "cloud_sync_icon_pack_hint",
+      "value": "Icon pack files and preferences are backed up to Huawei Cloud along with your tokens and automatically restored to all devices."
+    },
+    {
+      "name": "cloud_sync_icon_pack_state_backing_up",
+      "value": "Backing up..."
+    },
+    {
+      "name": "cloud_sync_icon_pack_state_restoring",
+      "value": "Restoring..."
+    },
+    {
+      "name": "cloud_sync_icon_pack_state_clearing",
+      "value": "Clearing..."
+    },
+    {
+      "name": "cloud_sync_icon_pack_state_checking",
+      "value": "Checking..."
     }
   ]
 }

--- a/entry/src/main/resources/zh_CN/element/string.json
+++ b/entry/src/main/resources/zh_CN/element/string.json
@@ -1278,7 +1278,7 @@
     },
     {
       "name": "cloud_sync_icon_pack_status_done_suffix",
-      "value": "个图标包已备份，"
+      "value": "个图标包已备份 "
     },
     {
       "name": "cloud_sync_icon_pack_status_none",

--- a/entry/src/main/resources/zh_CN/element/string.json
+++ b/entry/src/main/resources/zh_CN/element/string.json
@@ -226,7 +226,7 @@
     },
     {
       "name": "data_rdb_sync_des",
-      "value": "数据将会同步到一个组网环境中您华为账户登录的其他设备。"
+      "value": "数据将会同步到一个组网环境中您华为账户登录的其他设备。仅同步令牌数据，不同步图标包和偏好设置。"
     },
     {
       "name": "data_rdb_cloud_sync",
@@ -234,7 +234,7 @@
     },
     {
       "name": "data_rdb_cloud_sync_des",
-      "value": "将应用数据备份至华为云，数据将安全存储在华为云端。"
+      "value": "将令牌和图标包数据备份至华为云，数据将安全存储在华为云端。"
     },
     {
       "name": "data_rdb_sync_details",
@@ -402,7 +402,7 @@
     },
     {
       "name": "data_kv_sync_manual_des",
-      "value": "同步当前所有令牌到其他设备"
+      "value": "同步当前所有令牌到其他设备（不含图标包）"
     },
     {
       "name": "cloud_backup_manual",
@@ -1263,6 +1263,58 @@
     {
       "name": "importer_uri_desc",
       "value": "粘贴 otpauth:// 链接导入令牌"
+    },
+    {
+      "name": "icon_pack_cloud_backup_hint",
+      "value": "图标包设置随华为云备份自动同步至您的所有设备。详见「备份与迁移 > 华为云备份」。"
+    },
+    {
+      "name": "cloud_sync_icon_pack_title",
+      "value": "图标包备份"
+    },
+    {
+      "name": "cloud_sync_icon_pack_status",
+      "value": "备份状态"
+    },
+    {
+      "name": "cloud_sync_icon_pack_status_done_suffix",
+      "value": "个图标包已备份，"
+    },
+    {
+      "name": "cloud_sync_icon_pack_status_none",
+      "value": "未备份"
+    },
+    {
+      "name": "cloud_sync_icon_pack_status_empty",
+      "value": "无图标包"
+    },
+    {
+      "name": "cloud_sync_icon_pack_last_time",
+      "value": "上次备份"
+    },
+    {
+      "name": "cloud_sync_icon_pack_source_device",
+      "value": "来源设备"
+    },
+    {
+      "name": "cloud_sync_icon_pack_hint",
+      "value": "图标包文件和启用设置随令牌一起备份到华为云，恢复时自动还原至所有设备。"
+    },
+    {
+      "name": "cloud_sync_icon_pack_state_backing_up",
+      "value": "正在备份..."
+    },
+    {
+      "name": "cloud_sync_icon_pack_state_restoring",
+      "value": "正在恢复..."
+    },
+    {
+      "name": "cloud_sync_icon_pack_state_clearing",
+      "value": "正在清理..."
+    },
+    {
+      "name": "cloud_sync_icon_pack_state_checking",
+      "value": "正在检查..."
     }
   ]
 }

--- a/entry/src/main/resources/zh_TW/element/string.json
+++ b/entry/src/main/resources/zh_TW/element/string.json
@@ -226,7 +226,7 @@
     },
     {
       "name": "data_rdb_sync_des",
-      "value": "資料將會同步到一個組網環境中您華為帳號登入的其他裝置。"
+      "value": "資料將會同步到一個組網環境中您華為帳號登入的其他裝置。僅同步令牌資料，不同步圖示包和偏好設定。"
     },
     {
       "name": "data_rdb_cloud_sync",
@@ -234,7 +234,7 @@
     },
     {
       "name": "data_rdb_cloud_sync_des",
-      "value": "將應用資料備份至華為雲端，資料將安全存儲在華為雲端。"
+      "value": "將令牌和圖示包資料備份至華為雲端，資料將安全存儲在華為雲端。"
     },
     {
       "name": "data_rdb_sync_details",
@@ -402,7 +402,7 @@
     },
     {
       "name": "data_kv_sync_manual_des",
-      "value": "同步當前所有令牌到其他裝置"
+      "value": "同步當前所有令牌到其他裝置（不含圖示包）"
     },
     {
       "name": "cloud_backup_manual",
@@ -1263,6 +1263,58 @@
     {
       "name": "importer_uri_desc",
       "value": "貼上 otpauth:// 鏈接匯入令牌"
+    },
+    {
+      "name": "icon_pack_cloud_backup_hint",
+      "value": "圖示包設定隨華為雲備份自動同步至您的所有裝置。詳見「備份與遷移 > 華為雲備份」。"
+    },
+    {
+      "name": "cloud_sync_icon_pack_title",
+      "value": "圖示包備份"
+    },
+    {
+      "name": "cloud_sync_icon_pack_status",
+      "value": "備份狀態"
+    },
+    {
+      "name": "cloud_sync_icon_pack_status_done_suffix",
+      "value": "個圖示包已備份，"
+    },
+    {
+      "name": "cloud_sync_icon_pack_status_none",
+      "value": "未備份"
+    },
+    {
+      "name": "cloud_sync_icon_pack_status_empty",
+      "value": "無圖示包"
+    },
+    {
+      "name": "cloud_sync_icon_pack_last_time",
+      "value": "上次備份"
+    },
+    {
+      "name": "cloud_sync_icon_pack_source_device",
+      "value": "來源設備"
+    },
+    {
+      "name": "cloud_sync_icon_pack_hint",
+      "value": "圖示包檔案和啟用設定隨令牌一起備份到華為雲，恢復時自動還原至所有裝置。"
+    },
+    {
+      "name": "cloud_sync_icon_pack_state_backing_up",
+      "value": "正在備份..."
+    },
+    {
+      "name": "cloud_sync_icon_pack_state_restoring",
+      "value": "正在恢復..."
+    },
+    {
+      "name": "cloud_sync_icon_pack_state_clearing",
+      "value": "正在清理..."
+    },
+    {
+      "name": "cloud_sync_icon_pack_state_checking",
+      "value": "正在檢查..."
     }
   ]
 }


### PR DESCRIPTION
## 变更摘要

本次提交包含 4 项改动，主要是将搜索功能抽取为独立页面，并修复多个 UI 显示问题。

## 变更详情

### refactor: 搜索功能改为独立页面（98eb0db）
- 将 `TokenListPage` 中的搜索功能抽取为独立的 `TokenSearchPage` 页面
- 新增 `entry/src/main/ets/pages/TokenSearchPage.ets`
- 优化代码结构，降低单页面复杂度

### fix: 优化标题栏安全区裁剪显示（3a3e416）
- 标题栏使能安全区裁剪，设置`List`组件`.clip(false)`实现顶部模糊，且不需要放空的不可见`ListItem`

### fix(web): 调整网页组件显示设置（d8b5b96）
- 调整 Web 组件的显示配置禁用`.fileAccess`

### fix(ui): 调整设置页 Sheet 顶部安全区裁剪（dc298c1）
- 设置页 Sheet 顶部标题栏使能安全区避让